### PR TITLE
Added auto maintenance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -2,8 +2,8 @@ name: Check links
 
 on:
   schedule:
-    # Run on the first day of every month at 08:00 UTC
-    - cron: "0 8 1 * *"
+    # Run every Monday at 08:00 UTC
+    - cron: "0 8 * * 1"
   workflow_dispatch: # allow manual runs
 
 jobs:
@@ -43,8 +43,8 @@ jobs:
       - name: Check site pages are reachable
         run: |
           BASE="https://meighenbergers.github.io/jc-ppi"
-          for PATH in "/" "/archive.html"; do
-            URL="${BASE}${PATH}"
+          for PAGE in "/" "/archive.html" "/stats.html" "/resources.html"; do
+            URL="${BASE}${PAGE}"
             HTTP_STATUS=$(curl --silent --output /dev/null --write-out "%{http_code}" \
               --max-time 30 --location "$URL")
             echo "$URL → HTTP $HTTP_STATUS"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,38 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "site/assets/js/**"
+      - "tests/**"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/test.yml"
+  pull_request:
+    paths:
+      - "site/assets/js/**"
+      - "tests/**"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/test.yml"
+
+jobs:
+  test:
+    name: Unit tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -100,11 +100,8 @@ they submit, so their papers appear on the site without manual action.
    - `doPost` — handles vote/edit/remove mutations from the site (optional;
      see [INTERACTIVITY.md](INTERACTIVITY.md) for setup)
 
-   At minimum, update the `APPROVED` array at the top:
-
-   ```js
-   const APPROVED = ['alice@example.com', 'bob@example.com'];
-   ```
+   The script reads the approved member list from a **Members** sheet tab
+   (see Step 5a below) — no code editing needed to add or remove members.
 
 4. Save (Ctrl+S).
 5. Click the **Triggers** icon (clock, left sidebar) → **+ Add Trigger**:
@@ -114,8 +111,17 @@ they submit, so their papers appear on the site without manual action.
 6. Save and grant the requested permissions.
 
 For **one-off approvals**: open the private sheet and manually tick the
-Approved checkbox in column F for that row. To add a recurring member
-permanently, add their email to the `APPROVED` array.
+Approved checkbox in column F for that row.
+
+### Step 5a — Create the Members tab
+
+The `onFormSubmit` script looks for a sheet tab called **Members** to find the
+approved member list. Create it once:
+
+1. In the spreadsheet (either the private response sheet or the same workbook),
+   click **+** to add a new tab and name it `Members`.
+2. In column A, add one email address per row — no header needed.
+3. To add or remove a member in future, just edit this tab. No code changes required.
 
 ---
 
@@ -132,11 +138,22 @@ export const CONFIG = {
   formUrl: 'https://docs.google.com/forms/d/e/YOUR_FORM_ID/viewform',
   // Apps Script /exec URL for vote/edit/remove (from INTERACTIVITY.md — leave blank to disable)
   mutateUrl: '',
+  // Meeting schedule — shown in the "When" block and used for the calendar download
+  meeting: {
+    day: 'Friday',
+    time: '2:30 PM CT',
+    timezoneLabel: 'Central Time',
+    timezone: 'America/Chicago',
+    icsAnchor: '20260306T143000', // DTSTART of a known occurrence
+    icsDurationEnd: '20260306T160000', // DTEND of that same occurrence
+    icsDayCode: 'FR', // RRULE BYDAY (FR=Friday, TH=Thursday, …)
+    slackUrl: '', // Slack channel URL — leave '' for plain text
+  },
 };
 ```
 
-Leave `mutateUrl` blank for now; it is only needed if you deploy the `doPost`
-web app (see [INTERACTIVITY.md](INTERACTIVITY.md)).
+To update the meeting time in future, change only the `meeting` fields — the
+home page "When" block and the calendar download will both update automatically.
 
 ---
 

--- a/docs/appscript.gs
+++ b/docs/appscript.gs
@@ -1,14 +1,33 @@
-const APPROVED = [
-  'example@gmail.com',
-];
+// Name of the sheet tab that lists approved member emails, one per row in column A.
+// To add or remove a member, edit that tab directly — no code changes needed.
+var MEMBERS_SHEET_NAME = 'Members';
 
 function onFormSubmit(e) {
-  const sheet = e.range.getSheet();
-  const row = e.range.getRow();
-  const email = (e.values[4] ?? '').trim().toLowerCase();
-  console.log('Email received:', JSON.stringify(email));  // ← here
-  const approved = APPROVED.map((a) => a.toLowerCase()).includes(email);
+  var sheet = e.range.getSheet();
+  var row = e.range.getRow();
+  var email = (e.values[4] ?? '').trim().toLowerCase();
+  var approved = _getApprovedEmails().includes(email);
   sheet.getRange(row, 6).setValue(approved);
+}
+
+/**
+ * Reads approved member emails from the Members tab.
+ * Returns an array of lowercase, trimmed email strings.
+ * Falls back to an empty array if the tab doesn't exist yet.
+ */
+function _getApprovedEmails() {
+  var ss = SpreadsheetApp.getActiveSpreadsheet();
+  var membersSheet = ss.getSheetByName(MEMBERS_SHEET_NAME);
+  if (!membersSheet) return [];
+  var lastRow = membersSheet.getLastRow();
+  if (lastRow < 1) return [];
+  return membersSheet
+    .getRange(1, 1, lastRow, 1)
+    .getValues()
+    .map(function (r) {
+      return r[0].toString().trim().toLowerCase();
+    })
+    .filter(Boolean);
 }
 
 

--- a/site/assets/js/app.js
+++ b/site/assets/js/app.js
@@ -288,15 +288,19 @@ function _renderSubfieldBar() {
  * weekly Friday journal-club meeting (2:30 PM CT, America/Chicago).
  */
 function _downloadCalendar() {
-  // Use a known Friday as the recurrence anchor (March 6, 2026)
+  const m = CONFIG.meeting ?? {};
+  const tz = m.timezone ?? 'America/Chicago';
+  const anchor = m.icsAnchor ?? '20260306T143000';
+  const end = m.icsDurationEnd ?? '20260306T160000';
+  const dayCode = m.icsDayCode ?? 'FR';
   const ics = [
     'BEGIN:VCALENDAR',
     'VERSION:2.0',
     'PRODID:-//jc-ppi//Iowa Particles & Plots JC//EN',
     'BEGIN:VEVENT',
-    'DTSTART;TZID=America/Chicago:20260306T143000',
-    'DTEND;TZID=America/Chicago:20260306T160000',
-    'RRULE:FREQ=WEEKLY;BYDAY=FR',
+    `DTSTART;TZID=${tz}:${anchor}`,
+    `DTEND;TZID=${tz}:${end}`,
+    `RRULE:FREQ=WEEKLY;BYDAY=${dayCode}`,
     'SUMMARY:Iowa Particles & Plots Journal Club',
     'DESCRIPTION:Weekly HEP paper discussion.\\nSubmit papers at https://meighenbergers.github.io/jc-ppi/\\nUpdates in the group Slack channel.',
     'BEGIN:VALARM',
@@ -331,6 +335,22 @@ async function init() {
       el.removeAttribute('href');
     }
   });
+
+  // Populate meeting info block from CONFIG.meeting
+  if (CONFIG.meeting) {
+    const { day, time, timezone, timezoneLabel, slackUrl } = CONFIG.meeting;
+    const whenEl = document.getElementById('meeting-when');
+    if (whenEl && day && time) {
+      const tzDisplay = timezoneLabel ? `${timezoneLabel} \u2014 ${timezone}` : timezone;
+      whenEl.innerHTML = `Every <strong>${day} at ${time}</strong>${tzDisplay ? ` (${tzDisplay})` : ''}`;
+    }
+    const updatesEl = document.getElementById('meeting-updates');
+    if (updatesEl && slackUrl) {
+      updatesEl.innerHTML =
+        `Room changes and cancellations are announced in the ` +
+        `<a href="${slackUrl}" target="_blank" rel="noopener"><strong>Slack channel</strong></a>.`;
+    }
+  }
 
   const container = document.getElementById('papers-container');
 
@@ -373,8 +393,10 @@ async function init() {
   } catch (err) {
     console.error(err);
     container.innerHTML = `<div class="error">
-      ⚠️ Could not load papers. Make sure the Google Sheet is published as CSV
-      and the URL in <code>config.js</code> is correct.<br>
+      ⚠️ <strong>Could not load papers.</strong> The most likely cause is the
+      Google Sheet CSV being unpublished or expired. In the sheet go to
+      <strong>File \u2192 Share \u2192 Publish to web</strong>, select the <em>Public</em>
+      tab as CSV, and click Publish (or re-publish).<br>
       <small>${err.message}</small>
     </div>`;
   }

--- a/site/assets/js/config.js
+++ b/site/assets/js/config.js
@@ -22,6 +22,20 @@ export const CONFIG = {
   // and paste the /exec URL here.  Leave blank to disable interactive controls.
   mutateUrl:
     'https://script.google.com/macros/s/AKfycbw6pJRxEQOXgLGLL3f0ih6HL05aSkwiKLipp0sB2o7Ec906WPxxVQ4ZmKlX742Aedix/exec',
+
+  // Meeting schedule — update these if the day, time, or location changes.
+  // day/time/timezoneLabel/timezone appear in the "When" block on the home page.
+  // icsAnchor/icsDurationEnd/icsDayCode drive the "Add to Calendar" download.
+  meeting: {
+    day: 'Friday',
+    time: '2:30 PM CT',
+    timezoneLabel: 'Central Time', // human-readable label shown next to the time
+    timezone: 'America/Chicago', // IANA timezone name used in the .ics file
+    icsAnchor: '20260306T143000', // DTSTART of a known occurrence — update if time changes
+    icsDurationEnd: '20260306T160000', // DTEND of that same occurrence
+    icsDayCode: 'FR', // RRULE BYDAY value (FR=Friday, TH=Thursday, etc.)
+    slackUrl: '', // Slack channel URL — leave '' to show plain text
+  },
 };
 
 // ── SHEET COLUMN MAP ────────────────────────────────────────

--- a/site/assets/js/inspire.js
+++ b/site/assets/js/inspire.js
@@ -17,20 +17,29 @@ import { normalizeArxivId, stripVersion, isValidArxivId } from './utils.js';
 
 // ── Cache ────────────────────────────────────────────────────
 
-const CACHE_KEY = 'inspire_meta_v4'; // bumped: v3 remap could overwrite valid data when INSPIRE returns un-padded eprint
-const CACHE_TTL_MS = 15 * 60 * 1000; // 15 minutes
+const CACHE_KEY = 'inspire_meta_v5'; // bumped: switched to localStorage with per-entry tiered TTL
+const TTL_RESOLVED_MS = 7 * 24 * 60 * 60 * 1000; // 7 days — fully indexed papers rarely change
+const TTL_NOT_FOUND_MS = 15 * 60 * 1000; //        15 min  — paper may appear on INSPIRE any time
+const TTL_INVALID_MS = 24 * 60 * 60 * 1000; //    24 h    — invalid IDs are stable
 const BATCH_SIZE = 25; // INSPIRE API page limit
+
+/** Returns the appropriate TTL for a cached metadata value. */
+function _ttlFor(data) {
+  if (data.invalidId) return TTL_INVALID_MS;
+  if (data.notFound) return TTL_NOT_FOUND_MS;
+  return TTL_RESOLVED_MS;
+}
 
 function _loadCache() {
   try {
-    return JSON.parse(sessionStorage.getItem(CACHE_KEY) || '{}');
+    return JSON.parse(localStorage.getItem(CACHE_KEY) || '{}');
   } catch {
     return {};
   }
 }
 function _saveCache(cache) {
   try {
-    sessionStorage.setItem(CACHE_KEY, JSON.stringify(cache));
+    localStorage.setItem(CACHE_KEY, JSON.stringify(cache));
   } catch {}
 }
 
@@ -80,7 +89,7 @@ export async function fetchPaperMetadata(ids) {
 
   cleanIds.forEach((id) => {
     const entry = cache[id];
-    if (entry && now - entry.ts < CACHE_TTL_MS) {
+    if (entry && now - entry.ts < (entry.ttl ?? TTL_NOT_FOUND_MS)) {
       // Serve from cache
       meta.set(id, entry.data);
     } else if (!isValidArxivId(id)) {
@@ -92,7 +101,7 @@ export async function fetchPaperMetadata(ids) {
       } else {
         const data = { invalidId: true };
         meta.set(id, data);
-        cache[id] = { ts: now, data };
+        cache[id] = { ts: now, data, ttl: _ttlFor(data) };
       }
     } else {
       toFetch.push(id);
@@ -127,7 +136,7 @@ export async function fetchPaperMetadata(ids) {
         found.add(arxivId);
         const parsed = _parseHit(m);
         meta.set(arxivId, parsed);
-        cache[arxivId] = { ts: now, data: parsed };
+        cache[arxivId] = { ts: now, data: parsed, ttl: _ttlFor(parsed) };
       });
 
       // Collect anything INSPIRE missed for arXiv validation
@@ -158,7 +167,7 @@ export async function fetchPaperMetadata(ids) {
     notFoundIds.forEach((id) => {
       const data = validOnArxiv.has(id) ? { notFound: true } : { invalidId: true };
       meta.set(id, data);
-      cache[id] = { ts: now, data };
+      cache[id] = { ts: now, data, ttl: _ttlFor(data) };
     });
   }
 
@@ -182,11 +191,11 @@ export async function fetchPaperMetadata(ids) {
     if (realData && !realData.invalidId) {
       const remapped = { ...realData, correctedId: paddedId };
       meta.set(originalId, remapped);
-      cache[originalId] = { ts: now, data: remapped };
+      cache[originalId] = { ts: now, data: remapped, ttl: _ttlFor(remapped) };
     } else {
       const d = { invalidId: true };
       meta.set(originalId, d);
-      cache[originalId] = { ts: now, data: d };
+      cache[originalId] = { ts: now, data: d, ttl: _ttlFor(d) };
     }
     // Always clean up the temporary padded key
     meta.delete(paddedId);

--- a/site/index.html
+++ b/site/index.html
@@ -55,14 +55,14 @@
       <div class="meeting-info">
         <div class="meeting-info-row">
           <span class="meeting-tag">When</span>
-          <span
-            >Every <strong>Friday at 2:30 PM CT</strong> (Central Time &mdash;
+          <span id="meeting-when"
+            >Every <strong>Friday at 2:30 PM CT</strong> (Central Time &mdash;
             America/Chicago)</span
           >
         </div>
         <div class="meeting-info-row">
           <span class="meeting-tag">Updates</span>
-          <span
+          <span id="meeting-updates"
             >Room changes and cancellations are announced in the
             <strong>Slack channel</strong>.</span
           >


### PR DESCRIPTION
Summary
Maintenance improvements to reduce ongoing admin work: meeting schedule moved to [config.js](vscode-file://vscode-app/c:/Users/smeighenberger/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (single place to update time/day/timezone), approved member list moved to a spreadsheet tab (no code deploy needed to add members), smarter INSPIRE metadata cache (tiered TTLs, [localStorage](vscode-file://vscode-app/c:/Users/smeighenberger/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)), clearer CSV-unpublished error, extended link checker, CI test job, and Dependabot for GitHub Actions.

Type of change
 Bug fix
 New feature / enhancement
 Content update (docs, README, etc.)
 CI / tooling change
Checklist
 Tested locally with python -m http.server 8000 --directory site
 No broken links introduced
 Formatting is consistent (run prettier --check or let CI verify)
 README / docs updated if relevant
Changes
[config.js](vscode-file://vscode-app/c:/Users/smeighenberger/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — added [meeting](vscode-file://vscode-app/c:/Users/smeighenberger/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) object ([day](vscode-file://vscode-app/c:/Users/smeighenberger/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [time](vscode-file://vscode-app/c:/Users/smeighenberger/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [timezone](vscode-file://vscode-app/c:/Users/smeighenberger/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [icsAnchor](vscode-file://vscode-app/c:/Users/smeighenberger/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [slackUrl](vscode-file://vscode-app/c:/Users/smeighenberger/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html), …); home page "When" block and [.ics](vscode-file://vscode-app/c:/Users/smeighenberger/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) calendar both driven from this, no more hardcoded values in HTML/JS
[appscript.gs](vscode-file://vscode-app/c:/Users/smeighenberger/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — replaced hardcoded APPROVED array with _getApprovedEmails() reading from a Members sheet tab; add/remove members by editing the spreadsheet only
[inspire.js](vscode-file://vscode-app/c:/Users/smeighenberger/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — switched cache from sessionStorage to [localStorage](vscode-file://vscode-app/c:/Users/smeighenberger/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) with tiered TTLs (7 days for resolved, 15 min for not-yet-indexed, 24 h for invalid); cache key bumped to v5
[app.js](vscode-file://vscode-app/c:/Users/smeighenberger/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — CSV fetch error now names the most likely cause and gives exact fix steps
[test.yml](vscode-file://vscode-app/c:/Users/smeighenberger/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — new CI job runs [npm test](vscode-file://vscode-app/c:/Users/smeighenberger/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) on every push/PR touching JS or tests
[dependabot.yml](vscode-file://vscode-app/c:/Users/smeighenberger/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — weekly Dependabot checks for GitHub Actions version updates
[check-links.yml](vscode-file://vscode-app/c:/Users/smeighenberger/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — schedule changed from monthly to weekly; /stats.html and /resources.html added to checked pages
[docs](vscode-file://vscode-app/c:/Users/smeighenberger/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — [SETUP.md](vscode-file://vscode-app/c:/Users/smeighenberger/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) updated for Members tab and [meeting](vscode-file://vscode-app/c:/Users/smeighenberger/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) config; INTERACTIVITY.md, ARXIV-GUIDE.md, CONTRIBUTING.md, [README.md](vscode-file://vscode-app/c:/Users/smeighenberger/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) split out and refreshed
Related issues
<!-- Closes #… -->