### PR TITLE
Bug fixes, better page loading, new tests, readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ After Sunday they roll automatically into the **Archive** — no manual action r
 
 **For anyone not yet in the list:** their submission is held until you open the private Google Sheet and manually tick the **Approved** checkbox in column F for that row. Changes appear on the site within about a minute.
 
-To add a recurring member permanently, add their email to the `APPROVED` array in your Apps Script project (Extensions → Apps Script → the `onFormSubmit` function).
+To add a recurring member permanently, add their email address (one per row) to the **Members** tab of your Google Sheet. No code changes are needed.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Iowa Particles & Plots Journal Club",
   "type": "module",
   "scripts": {
-    "test": "node --test tests/utils.test.js tests/data.test.js tests/inspire.test.js",
+    "test": "node --test tests/utils.test.js tests/data.test.js tests/inspire.test.js tests/config.test.js",
     "prepare": "git config core.hooksPath .githooks"
   },
   "engines": {

--- a/site/archive.html
+++ b/site/archive.html
@@ -45,6 +45,9 @@
           placeholder="Filter by title, author, keyword, submitter…"
           aria-label="Search archive"
         />
+        <button id="discussed-filter" class="sf-btn" aria-pressed="false">
+          &#9733; Discussed only
+        </button>
       </div>
 
       <div id="subfield-filter-bar" class="subfield-filter-bar"></div>

--- a/site/assets/css/style.css
+++ b/site/assets/css/style.css
@@ -639,10 +639,14 @@ main.prose {
 
 .archive-search-wrap {
   margin-bottom: 1.25rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 #archive-search {
-  width: 100%;
+  flex: 1;
+  min-width: 0;
   padding: 0.55rem 0.9rem;
   font-size: 0.9rem;
   border: 1px solid var(--border);
@@ -826,6 +830,43 @@ main.prose {
   background: var(--accent);
   color: #fff;
   border-color: var(--accent);
+}
+
+/* Week-level BibTeX export button (This Week page) */
+
+.bibtex-week-btn {
+  display: block;
+  margin: 0.75rem 0 0;
+  padding: 0.45rem 1rem;
+  font-size: 0.85rem;
+  font-family: inherit;
+  font-weight: 500;
+  background: var(--bg-alt);
+  color: var(--accent-sec);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    color 0.15s,
+    border-color 0.15s;
+}
+
+.bibtex-week-btn:hover {
+  background: var(--accent-sec);
+  color: #fff;
+  border-color: var(--accent-sec);
+}
+
+.bibtex-week-btn.copied {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
+
+.bibtex-week-btn:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
 }
 
 /* ── Meeting info block ──────────────────────────────────── */

--- a/site/assets/js/app.js
+++ b/site/assets/js/app.js
@@ -24,15 +24,30 @@ import { buildTable } from './table.js';
 /** Re-fetch interval for the This Week page (ms). */
 const POLL_INTERVAL = 2 * 60 * 1000; // 2 minutes
 
-// ── Subfield filter state ─────────────────────────────────────
+// ── Subfield filter state ───────────────────────────────────────────
 
-/** Currently active category chip, or null for ‘All’. */
+/** Currently active category chip, or null for 'All'. */
 let _activeCategory = null;
 
 /** Union of all categories discovered from loaded weeks. */
 const _knownCategories = new Set();
 
-// ── Helpers ───────────────────────────────────────────────────
+/** Whether the archive is filtered to discussed-only papers. */
+let _discussedOnly = false;
+
+// ── Poll change detection ──────────────────────────────────────────
+
+let _lastThisWeekHash = ''; // used to skip re-renders when nothing changed
+
+/**
+ * Fingerprints the current-week paper list so the poll can detect changes
+ * beyond a simple count: catches vote updates and discussed-flag toggles.
+ */
+export function weekHash(papers) {
+  return papers
+    .map((p) => `${p[COL.arxivId]}|${p[COL.votes] ?? 0}|${p[COL.discussed] ?? ''}`)
+    .join(';');
+}
 
 /** Fetch and parse all paper rows from the Google Sheet CSV. */
 async function fetchPapers() {
@@ -63,8 +78,6 @@ export function deduplicatePapers(papers) {
 
 // ── This Week ─────────────────────────────────────────────────
 
-let _lastThisWeekCount = -1; // used to skip re-renders when nothing changed
-
 async function renderThisWeek(papers, container, { force = false } = {}) {
   const monday = currentWeekStart();
   const sunday = new Date(monday);
@@ -85,9 +98,10 @@ async function renderThisWeek(papers, container, { force = false } = {}) {
     return new Date(a[COL.timestamp]) - new Date(b[COL.timestamp]);
   });
 
-  // Skip expensive re-render when paper count hasn't changed (poll path)
-  if (!force && thisWeek.length === _lastThisWeekCount) return;
-  _lastThisWeekCount = thisWeek.length;
+  // Skip expensive re-render when nothing has changed (poll path)
+  const hash = weekHash(thisWeek);
+  if (!force && hash === _lastThisWeekHash) return;
+  _lastThisWeekHash = hash;
 
   container.innerHTML = '';
 
@@ -105,6 +119,43 @@ async function renderThisWeek(papers, container, { force = false } = {}) {
     // Pass thisWeek:true only when the mutation endpoint is configured,
     // so vote/edit/remove controls appear only when they can actually work.
     container.appendChild(buildTable(thisWeek, metaMap, { thisWeek: !!CONFIG.mutateUrl }));
+
+    // ── Copy all BibTeX for this week ────────────────────────────────
+    const inspireIds = [...metaMap.values()].map((m) => m.inspireId).filter(Boolean);
+    if (inspireIds.length > 0) {
+      const bibBtn = document.createElement('button');
+      bibBtn.className = 'bibtex-week-btn';
+      bibBtn.textContent = `Copy all BibTeX (${inspireIds.length} paper${inspireIds.length !== 1 ? 's' : ''})`;
+      bibBtn.title = 'Fetch and copy BibTeX for all indexed papers this week';
+      bibBtn.addEventListener('click', async () => {
+        bibBtn.disabled = true;
+        bibBtn.textContent = 'Fetching…';
+        try {
+          const entries = await Promise.all(
+            inspireIds.map((id) =>
+              fetch(`https://inspirehep.net/api/literature/${id}?format=bibtex`, {
+                cache: 'force-cache',
+              }).then((r) => (r.ok ? r.text() : ''))
+            )
+          );
+          await navigator.clipboard.writeText(entries.filter(Boolean).join('\n\n'));
+          bibBtn.textContent = `Copied! (${inspireIds.length} entr${inspireIds.length !== 1 ? 'ies' : 'y'})`;
+          bibBtn.classList.add('copied');
+          setTimeout(() => {
+            bibBtn.textContent = `Copy all BibTeX (${inspireIds.length} paper${inspireIds.length !== 1 ? 's' : ''})`;
+            bibBtn.classList.remove('copied');
+            bibBtn.disabled = false;
+          }, 2500);
+        } catch {
+          bibBtn.textContent = 'Error — try again';
+          setTimeout(() => {
+            bibBtn.textContent = `Copy all BibTeX (${inspireIds.length} paper${inspireIds.length !== 1 ? 's' : ''})`;
+            bibBtn.disabled = false;
+          }, 2000);
+        }
+      });
+      container.appendChild(bibBtn);
+    }
   }
 
   const cta = document.getElementById('submit-cta');
@@ -168,7 +219,8 @@ async function renderArchive(papers, container) {
         const searchInput = document.getElementById('archive-search');
         const query = (searchInput?.value ?? '').trim().toLowerCase();
         const visible = _filterTable(table, query);
-        if ((query || _activeCategory) && visible === 0) details.style.display = 'none';
+        if ((query || _activeCategory || _discussedOnly) && visible === 0)
+          details.style.display = 'none';
         contentDiv.appendChild(table);
       });
     };
@@ -205,7 +257,8 @@ function _filterTable(table, query) {
     const textMatch = !query || tr.textContent.toLowerCase().includes(query);
     const catMatch =
       !_activeCategory || (tr.dataset.categories || '').split(',').includes(_activeCategory);
-    const match = textMatch && catMatch;
+    const discussedMatch = !_discussedOnly || tr.dataset.discussed === 'true';
+    const match = textMatch && catMatch && discussedMatch;
     tr.style.display = match ? '' : 'none';
     if (match) visible++;
   });
@@ -221,6 +274,16 @@ function initArchiveSearch() {
   const input = document.getElementById('archive-search');
   if (!input) return;
   input.addEventListener('input', _applyAllFilters);
+
+  const discussedBtn = document.getElementById('discussed-filter');
+  if (discussedBtn) {
+    discussedBtn.addEventListener('click', () => {
+      _discussedOnly = !_discussedOnly;
+      discussedBtn.classList.toggle('active', _discussedOnly);
+      discussedBtn.setAttribute('aria-pressed', String(_discussedOnly));
+      _applyAllFilters();
+    });
+  }
 }
 
 /**
@@ -234,7 +297,8 @@ function _applyAllFilters() {
     const table = details.querySelector('table');
     if (!table) return; // not yet loaded — filtered on load
     const visible = _filterTable(table, query);
-    details.style.display = (query || _activeCategory) && visible === 0 ? 'none' : '';
+    details.style.display =
+      (query || _activeCategory || _discussedOnly) && visible === 0 ? 'none' : '';
   });
 }
 
@@ -300,6 +364,9 @@ function _downloadCalendar() {
   const anchor = m.icsAnchor ?? '20260306T143000';
   const end = m.icsDurationEnd ?? '20260306T160000';
   const dayCode = m.icsDayCode ?? 'FR';
+  const siteUrl =
+    CONFIG.siteUrl ||
+    (typeof window !== 'undefined' ? window.location.href.replace(/[^/]*$/, '') : '');
   const ics = [
     'BEGIN:VCALENDAR',
     'VERSION:2.0',
@@ -309,7 +376,7 @@ function _downloadCalendar() {
     `DTEND;TZID=${tz}:${end}`,
     `RRULE:FREQ=WEEKLY;BYDAY=${dayCode}`,
     'SUMMARY:Iowa Particles & Plots Journal Club',
-    'DESCRIPTION:Weekly HEP paper discussion.\\nSubmit papers at https://meighenbergers.github.io/jc-ppi/\\nUpdates in the group Slack channel.',
+    `DESCRIPTION:Weekly HEP paper discussion.\\nSubmit papers at ${siteUrl}\\nUpdates in the group Slack channel.`,
     'BEGIN:VALARM',
     'TRIGGER:-PT30M',
     'ACTION:DISPLAY',

--- a/site/assets/js/config.js
+++ b/site/assets/js/config.js
@@ -23,6 +23,11 @@ export const CONFIG = {
   mutateUrl:
     'https://script.google.com/macros/s/AKfycbw6pJRxEQOXgLGLL3f0ih6HL05aSkwiKLipp0sB2o7Ec906WPxxVQ4ZmKlX742Aedix/exec',
 
+  // Base URL of the deployed site — used in the calendar .ics file description.
+  // Leave blank to derive from window.location automatically (correct for most deployments).
+  // Set explicitly if the auto-detected URL is wrong for your setup.
+  siteUrl: '',
+
   // Meeting schedule — update these if the day, time, or location changes.
   // day/time/timezoneLabel/timezone appear in the "When" block on the home page.
   // icsAnchor/icsDurationEnd/icsDayCode drive the "Add to Calendar" download.
@@ -44,6 +49,142 @@ export const CONFIG = {
 //   F (5) Removed    G (6) EditedComment          H (7) Votes
 // The three new columns (F-H) are written by the Apps Script.
 // Do not change these unless you reorder the Public tab columns.
+
+// ── STATS PAGE STOP WORDS ──────────────────────────────────
+// Words excluded from the title-word frequency chart on the Stats page.
+// Add or remove entries freely — lower-case, one word per entry.
+// Three groups are kept separate for readability:
+//   1. Standard English (articles, prepositions, conjunctions, …)
+//   2. Academic paper filler (common title verbs/nouns with no topic signal)
+//   3. HEP-specific boilerplate (universally present in the field)
+
+export const TITLE_STOP_WORDS = new Set([
+  // 1. Standard English
+  'a',
+  'an',
+  'the',
+  'and',
+  'or',
+  'but',
+  'nor',
+  'so',
+  'yet',
+  'in',
+  'of',
+  'for',
+  'with',
+  'at',
+  'by',
+  'from',
+  'via',
+  'on',
+  'to',
+  'into',
+  'onto',
+  'upon',
+  'over',
+  'under',
+  'about',
+  'as',
+  'its',
+  'it',
+  'is',
+  'are',
+  'be',
+  'been',
+  'being',
+  'has',
+  'have',
+  'had',
+  'was',
+  'were',
+  'do',
+  'does',
+  'did',
+  'this',
+  'that',
+  'these',
+  'those',
+  'their',
+  'they',
+  'them',
+  'we',
+  'us',
+  'our',
+  'i',
+  'not',
+  'no',
+
+  // 2. Academic paper filler
+  'probing',
+  'probe',
+  'exploring',
+  'explore',
+  'studying',
+  'study',
+  'searching',
+  'search',
+  'constraining',
+  'constraints',
+  'constraint',
+  'revisiting',
+  'revisited',
+  'towards',
+  'using',
+  'beyond',
+  'new',
+  'novel',
+  'first',
+  'improved',
+  'updated',
+  'precise',
+  'precision',
+  'general',
+  'effective',
+  'implications',
+  'implication',
+  'evidence',
+  'observation',
+  'observations',
+  'measurement',
+  'measurements',
+  'analysis',
+  'analyses',
+  'approach',
+  'approaches',
+  'case',
+  'cases',
+  'role',
+  'impact',
+  'effects',
+  'effect',
+  'via',
+  'through',
+  'within',
+  'based',
+  'induced',
+  'driven',
+  'dependent',
+  'independent',
+
+  // 3. HEP-specific boilerplate
+  'physics',
+  'particle',
+  'field',
+  'theory',
+  'model',
+  'models',
+  'standard',
+  'quantum',
+  'lhc',
+  'collider',
+  'colliders',
+  'cross',
+  'section',
+  'sections',
+  'energy',
+  'mass',
+]);
 
 export const COL = {
   timestamp: 0,

--- a/site/assets/js/stats.js
+++ b/site/assets/js/stats.js
@@ -10,147 +10,11 @@
    the sessionStorage cache populated by the other pages.
    ============================================================ */
 
-import { CONFIG, COL } from './config.js';
+import { CONFIG, COL, TITLE_STOP_WORDS } from './config.js';
 import { parseCsv, weekStart, fmtWeekRange, normalizeArxivId, stripVersion } from './utils.js';
 import { fetchPaperMetadata } from './inspire.js';
 
 const DEFAULT_YEAR = new Date().getFullYear();
-
-// ── Title word stop list ──────────────────────────────────────
-// Words excluded from the title-word frequency chart.
-// Add or remove entries freely — one word per line, lower-case.
-// Three groups are kept separate for readability:
-//   1. Standard English (articles, prepositions, conjunctions, …)
-//   2. Academic paper filler (common title verbs/nouns with no topic signal)
-//   3. HEP-specific boilerplate (universally present in the field)
-
-const TITLE_STOP_WORDS = new Set([
-  // 1. Standard English
-  'a',
-  'an',
-  'the',
-  'and',
-  'or',
-  'but',
-  'nor',
-  'so',
-  'yet',
-  'in',
-  'of',
-  'for',
-  'with',
-  'at',
-  'by',
-  'from',
-  'via',
-  'on',
-  'to',
-  'into',
-  'onto',
-  'upon',
-  'over',
-  'under',
-  'about',
-  'as',
-  'its',
-  'it',
-  'is',
-  'are',
-  'be',
-  'been',
-  'being',
-  'has',
-  'have',
-  'had',
-  'was',
-  'were',
-  'do',
-  'does',
-  'did',
-  'this',
-  'that',
-  'these',
-  'those',
-  'their',
-  'they',
-  'them',
-  'we',
-  'us',
-  'our',
-  'i',
-  'not',
-  'no',
-
-  // 2. Academic paper filler
-  'probing',
-  'probe',
-  'exploring',
-  'explore',
-  'studying',
-  'study',
-  'searching',
-  'search',
-  'constraining',
-  'constraints',
-  'constraint',
-  'revisiting',
-  'revisited',
-  'towards',
-  'using',
-  'beyond',
-  'new',
-  'novel',
-  'first',
-  'improved',
-  'updated',
-  'precise',
-  'precision',
-  'general',
-  'effective',
-  'implications',
-  'implication',
-  'evidence',
-  'observation',
-  'observations',
-  'measurement',
-  'measurements',
-  'analysis',
-  'analyses',
-  'approach',
-  'approaches',
-  'case',
-  'cases',
-  'role',
-  'impact',
-  'effects',
-  'effect',
-  'via',
-  'through',
-  'within',
-  'based',
-  'induced',
-  'driven',
-  'dependent',
-  'independent',
-
-  // 3. HEP-specific boilerplate
-  'physics',
-  'particle',
-  'field',
-  'theory',
-  'model',
-  'models',
-  'standard',
-  'quantum',
-  'lhc',
-  'collider',
-  'colliders',
-  'cross',
-  'section',
-  'sections',
-  'energy',
-  'mass',
-]);
 
 // ── Category color palette ────────────────────────────────────
 // ColorBrewer Dark2 (8) + steel blue + deep red.
@@ -197,7 +61,7 @@ function _gradientColor(r, g, b, rank, total) {
  * @param {Array<{label:string, value:number, color:string}>} rows  sorted desc
  * @param {string} [emptyMsg]
  */
-function _buildChart(title, rows, emptyMsg = 'No data yet.') {
+function _buildChart(title, rows, emptyMsg = 'No data yet.', { formatValue } = {}) {
   const section = document.createElement('section');
   section.className = 'stat-section';
 
@@ -237,7 +101,7 @@ function _buildChart(title, rows, emptyMsg = 'No data yet.') {
 
     const valueEl = document.createElement('span');
     valueEl.className = 'bar-value';
-    valueEl.textContent = value;
+    valueEl.textContent = formatValue ? formatValue(value) : value;
 
     row.appendChild(labelEl);
     row.appendChild(track);
@@ -328,7 +192,14 @@ export function computeSubmissionStats(year, allRows) {
     }
   });
 
-  return { papers, memberCounts, weekCounts, busiestKey };
+  const discussedCounts = new Map();
+  papers.forEach((p) => {
+    if ((p[COL.discussed] ?? '').trim().toUpperCase() !== 'TRUE') return;
+    const name = (p[COL.name] || '').trim() || 'Anonymous';
+    discussedCounts.set(name, (discussedCounts.get(name) ?? 0) + 1);
+  });
+
+  return { papers, memberCounts, weekCounts, busiestKey, discussedCounts };
 }
 
 // ── Stats renderer ────────────────────────────────────────────
@@ -341,7 +212,10 @@ async function renderStats(year, allRows) {
   const container = document.getElementById('stats-container');
   const subtitle = document.getElementById('stats-subtitle');
 
-  const { papers, memberCounts, weekCounts, busiestKey } = computeSubmissionStats(year, allRows);
+  const { papers, memberCounts, weekCounts, busiestKey, discussedCounts } = computeSubmissionStats(
+    year,
+    allRows
+  );
   const busiestWeekLabel = busiestKey ? fmtWeekRange(new Date(busiestKey)) : '—';
 
   const isCurrentYear = year === new Date().getFullYear();
@@ -370,6 +244,27 @@ async function renderStats(year, allRows) {
   });
   container.appendChild(summaryEl);
   container.appendChild(_buildChart(`Papers submitted in ${year} by member`, memberRows));
+
+  // Discussed-at-JC chart (CSV data only — no INSPIRE call needed)
+  if (discussedCounts.size > 0) {
+    const discussedRows = [...discussedCounts.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .map(([label, value], i, arr) => ({
+        label,
+        value,
+        color: _gradientColor(230, 171, 2, i, arr.length), // amber
+      }));
+    container.appendChild(
+      _buildChart(
+        `Discussed at JC in ${year} by member`,
+        discussedRows,
+        'No papers starred as discussed yet.',
+        {
+          formatValue: (v) => '★'.repeat(v) + ` (${v})`,
+        }
+      )
+    );
+  }
 
   if (papers.length === 0) return;
 

--- a/site/assets/js/table.js
+++ b/site/assets/js/table.js
@@ -44,8 +44,10 @@ export function buildTable(papers, metaMap = new Map(), { thisWeek = false } = {
     const tdName = tr.insertCell();
     tdName.textContent = (paper[COL.name] || '').trim() || '—';
 
-    // Attach categories as a data attribute for the subfield filter
+    // Attach filter data attributes
     tr.dataset.categories = (meta.categories ?? []).join(',');
+    tr.dataset.discussed =
+      (paper[COL.discussed] ?? '').trim().toUpperCase() === 'TRUE' ? 'true' : 'false';
 
     // Column 2 — Paper (title, authors, abstract, badge row, keyword pills)
     const tdPaper = tr.insertCell();

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -1,0 +1,73 @@
+/**
+ * config.test.js — Tests for config.js exported values.
+ * Run with: node --test tests/config.test.js
+ *
+ * Verifies the shape and content of TITLE_STOP_WORDS now that it lives in
+ * config.js and is part of the project's public configuration surface.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { TITLE_STOP_WORDS } from '../site/assets/js/config.js';
+
+// ── TITLE_STOP_WORDS ──────────────────────────────────────────
+
+describe('TITLE_STOP_WORDS', () => {
+  it('is a Set', () => {
+    assert.ok(TITLE_STOP_WORDS instanceof Set, 'expected TITLE_STOP_WORDS to be a Set');
+  });
+
+  it('is non-empty', () => {
+    assert.ok(TITLE_STOP_WORDS.size > 0, 'expected TITLE_STOP_WORDS to have entries');
+  });
+
+  // ── Group 1: standard English words ──────────────────────
+
+  it('contains common English articles and prepositions', () => {
+    for (const word of ['a', 'an', 'the', 'of', 'in', 'for', 'and', 'or']) {
+      assert.ok(TITLE_STOP_WORDS.has(word), `expected "${word}" to be a stop word`);
+    }
+  });
+
+  // ── Group 2: academic paper filler ───────────────────────
+
+  it('contains academic filler verbs and nouns', () => {
+    for (const word of ['probing', 'search', 'measurement', 'analysis', 'constraints']) {
+      assert.ok(TITLE_STOP_WORDS.has(word), `expected "${word}" to be a stop word`);
+    }
+  });
+
+  // ── Group 3: HEP-specific boilerplate ────────────────────
+
+  it('contains HEP boilerplate terms', () => {
+    for (const word of ['physics', 'particle', 'quantum', 'lhc', 'theory', 'model']) {
+      assert.ok(TITLE_STOP_WORDS.has(word), `expected "${word}" to be a stop word`);
+    }
+  });
+
+  // ── Regression guard: science-specific terms should NOT be blocked ────────
+
+  it('does not block specific physics terms that carry topic signal', () => {
+    // These should appear in the top-words chart when present in paper titles.
+    for (const word of ['wimp', 'axion', 'susy', 'higgs', 'supersymmetry', 'dark']) {
+      assert.ok(
+        !TITLE_STOP_WORDS.has(word),
+        `"${word}" should not be a stop word — it has topic signal`
+      );
+    }
+  });
+
+  it('all entries are lower-case strings', () => {
+    for (const word of TITLE_STOP_WORDS) {
+      assert.equal(typeof word, 'string', `expected string, got ${typeof word}`);
+      assert.equal(word, word.toLowerCase(), `"${word}" is not lower-case`);
+    }
+  });
+
+  it('all entries are non-empty', () => {
+    for (const word of TITLE_STOP_WORDS) {
+      assert.ok(word.length > 0, 'found empty string in TITLE_STOP_WORDS');
+    }
+  });
+});

--- a/tests/data.test.js
+++ b/tests/data.test.js
@@ -7,6 +7,10 @@
  *   - 7 intentional duplicate arXiv ID pairs (same paper, different submitters)
  *   - 1 versioned arXiv ID (2410.00841v2) to exercise stripVersion
  *   - Columns: Timestamp(0), Name(1), arXiv ID(2), Comment(3), Approved(4)
+ *
+ * Inline row fixtures (year 2099) are used for features that require columns
+ * beyond col 4 (Removed, EditedComment, Votes, Discussed) which are absent
+ * from the CSV fixture.
  */
 
 import { describe, it } from 'node:test';
@@ -16,7 +20,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { parseCsv, normalizeArxivId, stripVersion } from '../site/assets/js/utils.js';
-import { deduplicatePapers } from '../site/assets/js/app.js';
+import { deduplicatePapers, weekHash } from '../site/assets/js/app.js';
 import { computeSubmissionStats } from '../site/assets/js/stats.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -290,5 +294,136 @@ describe('computeSubmissionStats — week aggregation', () => {
         `week sum mismatch for ${year}: ${sumFromWeeks} vs ${papers.length}`
       );
     }
+  });
+});
+
+// ── weekHash ──────────────────────────────────────────────────
+
+// Helper: build a minimal paper row for weekHash.
+// Indices: 0=ts, 1=name, 2=arxivId, 3=comment, 4=approved,
+//          5=removed, 6=editedComment, 7=votes, 8=discussed
+const mkRow = (arxivId, votes = '', discussed = '') => [
+  'ts',
+  'name',
+  arxivId,
+  'comment',
+  'TRUE',
+  '',
+  '',
+  votes,
+  discussed,
+];
+
+describe('weekHash', () => {
+  it('returns a string', () => {
+    assert.equal(typeof weekHash([mkRow('2401.00001', '5', 'TRUE')]), 'string');
+  });
+
+  it('returns an empty string for an empty array', () => {
+    assert.equal(weekHash([]), '');
+  });
+
+  it('same inputs produce the same hash', () => {
+    const papers = [mkRow('2401.00001', '3', 'TRUE'), mkRow('2401.00002', '0', '')];
+    assert.equal(weekHash(papers), weekHash(papers));
+  });
+
+  it('incrementing a vote count changes the hash', () => {
+    const before = [mkRow('2401.00001', '3', ''), mkRow('2401.00002', '1', '')];
+    const after = [mkRow('2401.00001', '4', ''), mkRow('2401.00002', '1', '')];
+    assert.notEqual(weekHash(before), weekHash(after));
+  });
+
+  it('toggling discussed on a paper changes the hash', () => {
+    const before = [mkRow('2401.00001', '0', '')];
+    const after = [mkRow('2401.00001', '0', 'TRUE')];
+    assert.notEqual(weekHash(before), weekHash(after));
+  });
+
+  it('adding a paper changes the hash', () => {
+    const before = [mkRow('2401.00001', '0', '')];
+    const after = [mkRow('2401.00001', '0', ''), mkRow('2401.00002', '0', '')];
+    assert.notEqual(weekHash(before), weekHash(after));
+  });
+
+  it('removing a paper changes the hash', () => {
+    const before = [mkRow('2401.00001', '0', ''), mkRow('2401.00002', '0', '')];
+    const after = [mkRow('2401.00001', '0', '')];
+    assert.notEqual(weekHash(before), weekHash(after));
+  });
+
+  it('changing only a comment (untracked field) does not change the hash', () => {
+    // weekHash only tracks arxivId, votes, and discussed—not the comment
+    const before = [['ts', 'name', '2401.00001', 'Old comment', 'TRUE', '', '', '0', '']];
+    const after = [['ts', 'name', '2401.00001', 'New comment', 'TRUE', '', '', '0', '']];
+    assert.equal(weekHash(before), weekHash(after));
+  });
+});
+
+// ── computeSubmissionStats — discussedCounts ────────────────────────────
+
+// Inline rows in year 2099 to avoid collisions with the fixture.
+// Full column set: [ts(0), name(1), arxivId(2), comment(3), approved(4),
+//                   removed(5), editedComment(6), votes(7), discussed(8)]
+const mkDisc = (name, arxivId, discussed) => [
+  '2099-01-07 10:00:00',
+  name,
+  arxivId,
+  '',
+  'TRUE',
+  '',
+  '',
+  '0',
+  discussed,
+];
+
+// Six rows: 5 unique arXiv IDs + one duplicate of the first.
+// After dedup: 5 papers remain.
+const DISC_ROWS = [
+  mkDisc('Alice Chen', '9901.00001', 'TRUE'), // Alice: discussed
+  mkDisc('Alice Chen', '9901.00002', 'TRUE'), // Alice: discussed (2 total)
+  mkDisc('Bob Martinez', '9901.00003', 'TRUE'), // Bob: discussed
+  mkDisc('Bob Martinez', '9901.00004', ''), // Bob: NOT discussed
+  mkDisc('Carol Liu', '9901.00005', 'FALSE'), // Carol: explicitly FALSE
+  mkDisc('Alice Chen', '9901.00001', 'TRUE'), // duplicate — dropped by dedup
+];
+
+describe('computeSubmissionStats — discussedCounts', () => {
+  it('counts discussed papers correctly per submitter', () => {
+    const { discussedCounts } = computeSubmissionStats(2099, DISC_ROWS);
+    assert.equal(discussedCounts.get('Alice Chen'), 2);
+    assert.equal(discussedCounts.get('Bob Martinez'), 1);
+  });
+
+  it('does not include submitters with no discussed papers', () => {
+    const { discussedCounts } = computeSubmissionStats(2099, DISC_ROWS);
+    assert.ok(!discussedCounts.has('Carol Liu'), 'Carol had no discussed papers');
+  });
+
+  it('undiscussed paper by the same submitter does not inflate their count', () => {
+    // Bob has one discussed and one undiscussed paper; count should be 1, not 2
+    const { discussedCounts } = computeSubmissionStats(2099, DISC_ROWS);
+    assert.equal(discussedCounts.get('Bob Martinez'), 1);
+  });
+
+  it('dedup runs before counting: duplicate discussed paper counts once', () => {
+    // 9901.00001 appears twice in DISC_ROWS (both discussed=TRUE, both Alice).
+    // After dedup only one row survives, so Alice’s count is 2, not 3.
+    const { discussedCounts } = computeSubmissionStats(2099, DISC_ROWS);
+    assert.equal(discussedCounts.get('Alice Chen'), 2);
+  });
+
+  it('returns an empty Map when no rows have Discussed = TRUE', () => {
+    const { discussedCounts } = computeSubmissionStats(2099, [
+      mkDisc('Alice Chen', '9901.99001', ''),
+      mkDisc('Bob Martinez', '9901.99002', 'FALSE'),
+    ]);
+    assert.equal(discussedCounts.size, 0);
+  });
+
+  it('fixture rows (no col 8) produce empty discussedCounts', () => {
+    // The fixture CSV only has columns 0–4; p[8] is undefined, treated as not discussed.
+    const { discussedCounts } = computeSubmissionStats(2021, allRows);
+    assert.equal(discussedCounts.size, 0);
   });
 });

--- a/tests/runner.html
+++ b/tests/runner.html
@@ -116,11 +116,13 @@
 
       // ── Synthetic test data ───────────────────────────────────────────────────────
 
-      // Minimal paper rows: [timestamp, name, arxivId, comment, approved]
+      // Minimal paper rows:
+      // [timestamp(0), name(1), arxivId(2), comment(3), approved(4),
+      //  removed(5), editedComment(6), votes(7), discussed(8)]
       const PAPERS = [
-        ['2024-01-08', 'Alice Chen', '2401.00001', 'Great paper', 'TRUE'],
-        ['2024-01-09', 'Bob Martinez', '2401.00002', 'Very nice', 'TRUE'],
-        ['2024-01-10', 'Carol Liu', '2401.00003', '', 'TRUE'],
+        ['2024-01-08', 'Alice Chen', '2401.00001', 'Great paper', 'TRUE', '', '', '3', 'TRUE'],
+        ['2024-01-09', 'Bob Martinez', '2401.00002', 'Very nice', 'TRUE', '', '', '1', ''],
+        ['2024-01-10', 'Carol Liu', '2401.00003', '', 'TRUE', '', '', '0', ''],
       ];
 
       // Minimal metaMap — keyed by normalised arXiv ID
@@ -158,8 +160,7 @@
         test('produces one <tr> per paper', async () => {
           const table = buildTable(PAPERS, META_MAP);
           const rows = table.querySelectorAll('tbody tr');
-          // Each paper has a title row + a badge row → 2 rows per paper = 6 total
-          assertEqual(rows.length, PAPERS.length * 2);
+          assertEqual(rows.length, PAPERS.length);
         });
       });
 
@@ -183,20 +184,13 @@
         test('row for paper without metaMap entry has empty data-categories', async () => {
           const table = buildTable(PAPERS, META_MAP);
           const rows = [...table.querySelectorAll('tbody tr')];
-          // Carol's paper (no metaMap entry) should have empty or absent categories
-          const carolRows = rows.filter((r) => {
-            // badge rows carry dataset.categories; find Carol's badge row
-            const sibling = r.previousElementSibling;
-            return sibling && sibling.textContent.includes('Carol');
-          });
-          // All carol rows should have empty categories
-          for (const r of carolRows) {
-            assertEqual(
-              r.dataset.categories ?? '',
-              '',
-              `Carol's row should have empty categories, got: "${r.dataset.categories}"`
-            );
-          }
+          const carolRow = rows.find((r) => r.cells[0]?.textContent === 'Carol Liu');
+          assert(carolRow != null, "could not find Carol's row");
+          assertEqual(
+            carolRow.dataset.categories ?? '',
+            '',
+            `Carol's row should have empty categories, got: "${carolRow.dataset.categories}"`
+          );
         });
       });
 
@@ -214,12 +208,18 @@
           assertEqual(buttons.length, 0, 'should be no BibTeX button when inspireId is missing');
         });
 
-        test('BibTeX buttons have correct INSPIRE id in data-inspire-id', async () => {
+        test("BibTeX button text is 'Cite BibTeX'", async () => {
           const table = buildTable(PAPERS, META_MAP);
           const btn = table.querySelector('.bibtex-btn');
           assert(btn != null, 'expected a .bibtex-btn element');
-          const id = parseInt(btn.dataset.inspireId ?? btn.getAttribute('data-inspire-id'), 10);
-          assert([1001, 1002].includes(id), `unexpected inspireId: ${id}`);
+          assertEqual(btn.textContent, 'Cite BibTeX');
+        });
+
+        test('BibTeX button has a title attribute', async () => {
+          const table = buildTable(PAPERS, META_MAP);
+          const btn = table.querySelector('.bibtex-btn');
+          assert(btn != null, 'expected a .bibtex-btn element');
+          assert(btn.title.length > 0, 'expected a non-empty title attribute');
         });
 
         test('exactly 2 BibTeX buttons for 2 papers with metaMap entries', async () => {
@@ -256,6 +256,61 @@
           const table = buildTable([], new Map());
           const rows = table.querySelectorAll('tbody tr');
           assertEqual(rows.length, 0);
+        });
+      });
+
+      suite('buildTable — data-discussed attribute', () => {
+        test('row with discussed=TRUE has data-discussed="true"', async () => {
+          const table = buildTable(PAPERS, META_MAP);
+          const rows = [...table.querySelectorAll('tbody tr')];
+          const aliceRow = rows.find((r) => r.cells[0]?.textContent === 'Alice Chen');
+          assert(aliceRow != null, "could not find Alice's row");
+          assertEqual(aliceRow.dataset.discussed, 'true');
+        });
+
+        test('row with discussed="" has data-discussed="false"', async () => {
+          const table = buildTable(PAPERS, META_MAP);
+          const rows = [...table.querySelectorAll('tbody tr')];
+          const bobRow = rows.find((r) => r.cells[0]?.textContent === 'Bob Martinez');
+          assert(bobRow != null, "could not find Bob's row");
+          assertEqual(bobRow.dataset.discussed, 'false');
+        });
+
+        test('every row has a data-discussed attribute', async () => {
+          const table = buildTable(PAPERS, META_MAP);
+          table.querySelectorAll('tbody tr').forEach((tr) => {
+            assert(
+              tr.dataset.discussed === 'true' || tr.dataset.discussed === 'false',
+              `unexpected data-discussed value: "${tr.dataset.discussed}"`
+            );
+          });
+        });
+      });
+
+      suite('buildTable — discussed star badge', () => {
+        test('discussed row renders .paper-discussed badge', async () => {
+          const table = buildTable(PAPERS, META_MAP);
+          const rows = [...table.querySelectorAll('tbody tr')];
+          const aliceRow = rows.find((r) => r.cells[0]?.textContent === 'Alice Chen');
+          assert(aliceRow != null, "could not find Alice's row");
+          const badge = aliceRow.cells[1]?.querySelector('.paper-discussed');
+          assert(badge != null, "expected .paper-discussed badge on Alice's row");
+        });
+
+        test('non-discussed row has no .paper-discussed badge', async () => {
+          const table = buildTable(PAPERS, META_MAP);
+          const rows = [...table.querySelectorAll('tbody tr')];
+          const bobRow = rows.find((r) => r.cells[0]?.textContent === 'Bob Martinez');
+          assert(bobRow != null, "could not find Bob's row");
+          const badge = bobRow.cells[1]?.querySelector('.paper-discussed');
+          assert(badge == null, "Bob's row should not have a .paper-discussed badge");
+        });
+
+        test('badge text contains the star character \u2605', async () => {
+          const table = buildTable(PAPERS, META_MAP);
+          const badge = table.querySelector('.paper-discussed');
+          assert(badge != null, 'expected at least one .paper-discussed badge');
+          assert(badge.textContent.includes('\u2605'), 'badge should contain the \u2605 character');
         });
       });
 


### PR DESCRIPTION
## Summary

Maintenance and feature pass across the full codebase: fixes a poll change-detection bug (votes and discussed-flag updates were invisible until a new paper was added), removes a hardcoded URL from the calendar export, moves `TITLE_STOP_WORDS` to `config.js`, and adds three user-facing features — a "Discussed only" archive filter, a week-level BibTeX export button, and a "discussed papers per member" chart on the Stats page. Test coverage is extended to match all new behaviour.

## Type of change

- [x] Bug fix
- [x] New feature / enhancement
- [x] Content update (docs, README, etc.)
- [ ] CI / tooling change

## Checklist

- [ ] Tested locally with `python -m http.server 8000 --directory site`
- [x] No broken links introduced
- [ ] Formatting is consistent (run `prettier --check` or let CI verify)
- [x] README / docs updated if relevant

## Changes in detail

**Bug fixes**
- Poll re-render now fingerprints arXiv ID + vote count + discussed flag per paper, so vote increments and star toggles surface without a new submission being required
- Calendar `.ics` description URL is now derived from `window.location` (or an explicit `siteUrl` in `config.js`) instead of a hardcoded `meighenbergers.github.io` path

**New features**
- Archive: "★ Discussed only" toggle button filters all loaded weeks to papers marked as discussed at JC
- This Week: "Copy all BibTeX" button fetches and copies BibTeX for all INSPIRE-indexed papers in the current week in one click
- Stats: new "Discussed at JC by member" amber bar chart, rendered from CSV data (no extra API call), with star-repeat formatting (★★★ (3))

**Maintainability**
- `TITLE_STOP_WORDS` moved from `stats.js` to `config.js` where admins naturally look for site configuration
- README weekly-workflow section updated to reflect the current Members-tab approval flow (removed stale reference to editing the `APPROVED` array in Apps Script)

**Tests** (`npm test`: 118 → 140 passing)
- `weekHash` exported from `app.js`; 8 new unit tests covering stability, vote changes, discussed toggles, and paper count changes
- `computeSubmissionStats` — 6 new `discussedCounts` tests using inline 2099 fixtures (dedup interaction, FALSE/blank exclusion, fixture rows with no col 8)
- `config.test.js` (new file) — 7 tests for `TITLE_STOP_WORDS` shape, content, and regression guard against over-blocking signal-carrying HEP terms
- `runner.html` — fixed 3 previously incorrect DOM tests; added `data-discussed` attribute suite (3 tests) and `.paper-discussed` star badge suite (3 tests); `PAPERS` fixture extended to full 9-column format

## Related issues

<!-- Closes #… -->