### PR TITLE
Add trending and simpler config. Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,23 +45,38 @@ INSPIRE-HEP API fills in title, authors, abstract, citations, BibTeX
 Papers submitted during the current Monday–Sunday window appear on the **This Week** page.
 After Sunday they roll automatically into the **Archive** — no manual action required.
 
+A second pipeline keeps the **Trending Papers** section on the home page up to date:
+
+```
+Apps Script triggers on Monday and Wednesday morning
+        ↓
+refreshTrendingPapers() queries INSPIRE-HEP for top-cited hep-ph papers
+        ↓
+Results written to the Trending tab in the Google Sheet
+        ↓
+Site fetches Trending tab as CSV → renders dedicated Trending section on home page
+        ↓
+weeklySlackReminder reads the same Trending tab (no live API calls needed)
+```
+
 ---
 
 ## Features
 
-| Feature                | Details                                                                         |
-| ---------------------- | ------------------------------------------------------------------------------- |
-| **Auto metadata**      | Title, authors, abstract, citation count fetched from INSPIRE-HEP               |
-| **BibTeX copy**        | One-click copy of the INSPIRE BibTeX entry                                      |
-| **arXiv validation**   | Invalid IDs shown in red; IDs not yet on INSPIRE shown in amber                 |
-| **ID auto-correction** | Three-digit-prefix IDs (e.g. `708.1137`) are automatically tried as `0708.1137` |
-| **Subfield filter**    | Archive can be filtered by broad HEP category (Pheno, Theory, Experiment, …)    |
-| **Year selector**      | Stats page can be scoped to a specific year                                     |
-| **This-week voting**   | Visitors can upvote papers on the current week's list                           |
-| **Inline editing**     | Submitters (or anyone) can update the suggestion comment for this week's papers |
-| **Remove entry**       | Entries can be removed from the live list (this week only, with confirmation)   |
-| **Calendar export**    | One-click `.ics` download for the next meeting                                  |
-| **Meeting info**       | Slack link, time, student guide, and calendar button on the home page           |
+| Feature                | Details                                                                                                                               |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| **Auto metadata**      | Title, authors, abstract, citation count fetched from INSPIRE-HEP                                                                     |
+| **BibTeX copy**        | One-click copy of the INSPIRE BibTeX entry                                                                                            |
+| **arXiv validation**   | Invalid IDs shown in red; IDs not yet on INSPIRE shown in amber                                                                       |
+| **ID auto-correction** | Three-digit-prefix IDs (e.g. `708.1137`) are automatically tried as `0708.1137`                                                       |
+| **Subfield filter**    | Archive can be filtered by broad HEP category (Pheno, Theory, Experiment, …)                                                          |
+| **Year selector**      | Stats page can be scoped to a specific year                                                                                           |
+| **This-week voting**   | Visitors can upvote papers on the current week's list                                                                                 |
+| **Inline editing**     | Submitters (or anyone) can update the suggestion comment for this week's papers                                                       |
+| **Remove entry**       | Entries can be removed from the live list (this week only, with confirmation)                                                         |
+| **Calendar export**    | One-click `.ics` download for the next meeting                                                                                        |
+| **Meeting info**       | Slack link, time, student guide, and calendar button on the home page                                                                 |
+| **Trending papers**    | Top-cited recent hep-ph papers from INSPIRE-HEP shown in a dedicated home-page section; refreshed automatically on Monday & Wednesday |
 
 ---
 
@@ -118,6 +133,7 @@ site/                        ← everything GitHub Pages serves
       sheet.js               ← Apps Script mutation wrapper (vote/edit/remove)
       table.js               ← DOM table builder
       app.js                 ← Page renderers and entry point
+      trending.js            ← Trending papers section renderer
 docs/
   SETUP.md                   ← Full deployment guide for your own instance
   CONTRIBUTING.md            ← How to suggest a paper / contribute to the site

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -63,19 +63,20 @@ check always passes.
 
 ### File map
 
-| File                        | What it does                                                       |
-| --------------------------- | ------------------------------------------------------------------ |
-| `site/assets/js/config.js`  | Google Sheet / Form URLs and column map — **start here for setup** |
-| `site/assets/js/utils.js`   | Week math, CSV parser, arXiv ID helpers, `isValidArxivId`          |
-| `site/assets/js/inspire.js` | INSPIRE-HEP API client, arXiv validation, ID auto-correction       |
-| `site/assets/js/sheet.js`   | Apps Script mutation wrapper (vote / edit / remove)                |
-| `site/assets/js/table.js`   | DOM table builder                                                  |
-| `site/assets/js/app.js`     | Page renderers and entry point                                     |
-| `site/assets/css/style.css` | All styling                                                        |
-| `site/index.html`           | This Week page                                                     |
-| `site/archive.html`         | Archive page (with subfield filter)                                |
-| `site/stats.html`           | Submission statistics by year                                      |
-| `site/resources.html`       | arXiv & INSPIRE-HEP guide                                          |
+| File                         | What it does                                                       |
+| ---------------------------- | ------------------------------------------------------------------ |
+| `site/assets/js/config.js`   | Google Sheet / Form URLs and column map — **start here for setup** |
+| `site/assets/js/utils.js`    | Week math, CSV parser, arXiv ID helpers, `isValidArxivId`          |
+| `site/assets/js/inspire.js`  | INSPIRE-HEP API client, arXiv validation, ID auto-correction       |
+| `site/assets/js/sheet.js`    | Apps Script mutation wrapper (vote / edit / remove)                |
+| `site/assets/js/table.js`    | DOM table builder                                                  |
+| `site/assets/js/app.js`      | Page renderers and entry point                                     |
+| `site/assets/js/trending.js` | Trending papers section renderer (display-only)                    |
+| `site/assets/css/style.css`  | All styling                                                        |
+| `site/index.html`            | This Week page                                                     |
+| `site/archive.html`          | Archive page (with subfield filter)                                |
+| `site/stats.html`            | Submission statistics by year                                      |
+| `site/resources.html`        | arXiv & INSPIRE-HEP guide                                          |
 
 ### Making changes
 

--- a/docs/INTERACTIVITY.md
+++ b/docs/INTERACTIVITY.md
@@ -127,6 +127,22 @@ the current-week page. To correct a star in the Archive, edit the
 
 ---
 
+### Trending refresh (automatic)
+
+When the **Trending Papers** section on the home page detects that the
+Trending CSV is empty (e.g. on a brand-new deployment before the first
+scheduled trigger fires), the site automatically sends a silent background
+POST to `doPost` with `{ action: "triggerTrendingRefresh" }`. This invokes
+`refreshTrendingPapers()` in the Apps Script, which fetches the latest data
+from INSPIRE-HEP and writes it to the Trending tab — the section will be
+populated on the next page load.
+
+No `arxivId` is required for this action. Under normal operation the refresh
+is handled by the Monday/Wednesday time-driven triggers described in
+[SETUP.md](SETUP.md#step-6b--set-up-the-trending-papers-section-optional).
+
+---
+
 ## Date guard
 
 The Apps Script `_findRow` function will only match a paper if its timestamp

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -107,10 +107,14 @@ they submit, so their papers appear on the site without manual action.
 1. Open the **private response sheet** (not the Public tab).
 2. **Extensions → Apps Script**.
 3. Replace any existing code with the contents of **`docs/appscript.gs`** from
-   this repository. The file contains two parts:
+   this repository. The file contains the following functions:
    - `onFormSubmit` — auto-approves known members on form submission
-   - `doPost` — handles vote/edit/remove mutations from the site (optional;
-     see [INTERACTIVITY.md](INTERACTIVITY.md) for setup)
+   - `doPost` — handles vote/edit/remove/trending-refresh mutations from the site
+     (optional; see [INTERACTIVITY.md](INTERACTIVITY.md) for setup)
+   - `weeklySlackReminder` — posts the weekly Thursday Slack message (reads
+     trending data from the Trending tab if present — see Step 6b)
+   - `refreshTrendingPapers` — fetches top-cited hep-ph papers from INSPIRE-HEP
+     and writes them to the Trending tab (see Step 6b)
 
    The script reads the approved member list from a **Members** sheet tab
    (see Step 5a below) — no code editing needed to add or remove members.
@@ -164,6 +168,67 @@ The reminder posts every Thursday between 1 and 2 pm in the Apps Script
 environment's timezone. It thanks submitters by name and links the top-voted
 paper (or nudges people to submit if none have been posted yet).
 
+If you have also completed Step 6b, the reminder will additionally list the
+top-cited paper from each INSPIRE-HEP category, sourced from the Trending tab
+(no live API calls at reminder time).
+
+---
+
+## Step 6b — Set up the Trending Papers section (optional)
+
+The home page can display a **Trending Papers** section showing the top-cited
+recent hep-ph papers from INSPIRE-HEP, grouped by category. Papers are
+refreshed automatically on Monday and Wednesday mornings.
+
+### Create the Trending tab
+
+1. In your Google Sheet, click **+** to add a new tab and name it `Trending`.
+2. In row 1 add the following headers (one per column, A through I):
+
+   | A        | B    | C       | D     | E        | F       | G           | H         | I               |
+   | -------- | ---- | ------- | ----- | -------- | ------- | ----------- | --------- | --------------- |
+   | Category | Rank | ArxivId | Title | Abstract | Authors | Affiliation | Citations | CitationsNoSelf |
+
+### Customise the categories (optional)
+
+At the top of `docs/appscript.gs`, inside the **CONFIGURATION** block, edit
+`INSPIRE_CATEGORIES` to add, remove, or rename search categories. Other
+relevant settings in the same block:
+
+| Variable                       | Default | Description                                 |
+| ------------------------------ | ------- | ------------------------------------------- |
+| `INSPIRE_LOOKBACK_WEEKS`       | `4`     | How many weeks back to search               |
+| `INSPIRE_RESULTS_PER_CATEGORY` | `3`     | Top N papers shown per category on the site |
+| `ABSTRACT_MAX_CHARS`           | `500`   | Maximum characters stored per abstract      |
+
+> All user-editable variables live at the very top of `appscript.gs` inside the
+> clearly marked CONFIGURATION block — no need to edit the logic further down.
+
+### Add the refresh triggers
+
+In the Apps Script editor (**Extensions → Apps Script → Triggers**):
+
+1. **+ Add Trigger**:
+   - Function: `refreshTrendingPapers`
+   - Event source: **Time-driven** → **Week timer** → **Monday** → **7am–8am**
+2. **+ Add Trigger**:
+   - Function: `refreshTrendingPapers`
+   - Event source: **Time-driven** → **Week timer** → **Wednesday** → **7am–8am**
+3. **Run `refreshTrendingPapers` once manually** from the editor (click the
+   function name in the dropdown then hit **Run**) to pre-populate the tab and
+   verify INSPIRE is responding correctly.
+
+### Publish the Trending tab as CSV
+
+1. Click **File → Share → Publish to web**.
+2. In the first dropdown choose the **Trending** tab; in the second choose
+   **Comma-separated values (.csv)**.
+3. Click **Publish** and confirm.
+4. Copy the URL and paste it into `trendingCsvUrl` in `config.js` (Step 7).
+
+> If `trendingCsvUrl` is left blank in `config.js`, the Trending section is
+> simply hidden — no other functionality is affected.
+
 ---
 
 ## Step 7 — Configure the site
@@ -179,6 +244,8 @@ export const CONFIG = {
   formUrl: 'https://docs.google.com/forms/d/e/YOUR_FORM_ID/viewform',
   // Apps Script /exec URL for vote/edit/remove (from INTERACTIVITY.md — leave blank to disable)
   mutateUrl: '',
+  // Published CSV URL for the Trending tab (from Step 6b — leave blank to hide the section)
+  trendingCsvUrl: '',
   // Meeting schedule — shown in the "When" block and used for the calendar download
   meeting: {
     day: 'Friday',

--- a/docs/appscript.gs
+++ b/docs/appscript.gs
@@ -1,6 +1,72 @@
-// Name of the sheet tab that lists approved member emails, one per row in column A.
-// To add or remove a member, edit that tab directly — no code changes needed.
-var MEMBERS_SHEET_NAME = 'Members';
+// ============================================================
+// CONFIGURATION — edit only this block
+// ============================================================
+
+// ── Sheet tab names ──────────────────────────────────────────
+var SHEET_NAME          = 'Public';   // main submissions tab
+var MEMBERS_SHEET_NAME  = 'Members';  // one approved email per row in column A
+var TRENDING_SHEET_NAME = 'Trending'; // written by refreshTrendingPapers
+
+// ── Slack Incoming Webhook ───────────────────────────────────
+// Go to https://api.slack.com/apps → Create App → Incoming Webhooks
+// Add a webhook for your channel and paste the URL below.
+var SLACK_WEBHOOK_URL = 'https://hooks.slack.com/services/YOUR/WEBHOOK/URL';
+
+// ── Site URL (used in Slack messages) ───────────────────────
+var SITE_URL = 'https://meighenbergers.github.io/jc-ppi/';
+
+// ── Meeting description (used in Slack messages) ─────────────
+var MEETING_TIME = '2:30pm';      // e.g. '2:30pm', '3pm'
+var MEETING_DAY  = 'tomorrow'; // e.g. 'tomorrow', 'Friday'
+
+// ── INSPIRE-HEP settings ─────────────────────────────────────
+// How many weeks back to look when finding trending papers.
+var INSPIRE_LOOKBACK_WEEKS = 4;
+
+// Top N papers to fetch per category (written to the Trending tab).
+var INSPIRE_RESULTS_PER_CATEGORY = 3;
+
+// Maximum characters to store for abstracts in the Trending tab.
+var ABSTRACT_MAX_CHARS = 500;
+
+// Categories to fetch from INSPIRE-HEP.
+// Each entry:
+//   label — display name on the website and in Slack
+//   emoji — prefix emoji
+//   extra — extra INSPIRE search term (empty string = all hep-ph)
+var INSPIRE_CATEGORIES = [
+  { label: 'Overall hep-ph', emoji: '🔬', extra: '' },
+  { label: 'Neutrinos',      emoji: '⚛️ ', extra: 'and a neutrino' },
+  { label: 'Dark Matter',    emoji: '🌑', extra: 'and a "dark matter"' }
+];
+
+// ── Public tab — 1-indexed column positions ──────────────────
+var COL_TIMESTAMP  = 1; // A — submission timestamp
+var COL_NAME       = 2; // B — submitter's name
+var COL_ARXIV      = 3; // C — arXiv ID as submitted (may be URL or bare ID)
+var COL_APPROVED   = 5; // E — "TRUE" when approved
+var COL_REMOVED    = 6; // F — "TRUE" when removed by a visitor
+var COL_EDITED     = 7; // G — edited comment text (empty = use original)
+var COL_VOTES      = 8; // H — running vote count
+var COL_DISCUSSED  = 9; // I — "TRUE" when starred as discussed at the meeting
+
+// ── Trending tab — 1-indexed column positions ────────────────
+var TCOL_CATEGORY         = 1; // A
+var TCOL_RANK             = 2; // B
+var TCOL_ARXIV_ID         = 3; // C
+var TCOL_TITLE            = 4; // D
+var TCOL_ABSTRACT         = 5; // E
+var TCOL_AUTHORS          = 6; // F
+var TCOL_AFFILIATION      = 7; // G
+var TCOL_CITATIONS        = 8; // H
+var TCOL_CITATIONS_NOSELF = 9; // I
+
+// ============================================================
+// END OF CONFIGURATION
+// ============================================================
+
+
+// ── Member approval on form submit ───────────────────────────
 
 function onFormSubmit(e) {
   var sheet = e.range.getSheet();
@@ -34,33 +100,19 @@ function _getApprovedEmails() {
 // ============================================================
 // Apps Script — doPost handler for jc-ppi interactivity
 // ============================================================
-// Paste this function into your existing Apps Script project
-// (Google Sheet → Extensions → Apps Script).
-//
 // DEPLOY as a web app:
 //   Deploy → New deployment → Type: Web app
 //   Execute as: Me
 //   Who has access: Anyone
 // Copy the /exec URL into config.js as mutateUrl.
 //
-// SHEET SETUP — add three columns to the right of column E
-// on the "Public" tab (or whatever SHEET_NAME is set to):
+// SHEET SETUP — add these columns to the right of column E
+// on the Public tab:
 //   F  Removed        (leave blank; Apps Script writes "TRUE" here)
 //   G  EditedComment  (leave blank; Apps Script writes the new comment)
 //   H  Votes          (set to 0 for existing rows; Apps Script increments)
+//   I  Discussed      (leave blank; Apps Script writes "TRUE" here)
 // ============================================================
-
-var SHEET_NAME   = 'Public'; // change if your tab is named differently
-
-// 1-indexed column positions in the Public tab
-var COL_ARXIV    = 3; // C — arXiv ID as submitted (may be URL or bare ID)
-var COL_APPROVED = 5; // E — "TRUE" when approved
-var COL_REMOVED   = 6; // F — "TRUE" when removed by a visitor
-var COL_EDITED    = 7; // G — edited comment text (empty = use original)
-var COL_VOTES     = 8; // H — running vote count
-var COL_DISCUSSED = 9; // I — "TRUE" when the paper was starred as discussed at the meeting
-
-// ── Entry point ───────────────────────────────────────────────
 
 function doPost(e) {
   var result = ContentService
@@ -70,10 +122,19 @@ function doPost(e) {
   try {
     var data    = JSON.parse(e.postData.contents);
     var action  = data.action;
-    var arxivId = (data.arxivId || '').toString().trim();
     var comment = (data.comment || '').toString();
 
-    if (!action)  throw new Error('Missing action');
+    if (!action) throw new Error('Missing action');
+
+    // ── Trigger a trending refresh (no arxivId needed) ────────
+    if (action === 'triggerTrendingRefresh') {
+      refreshTrendingPapers();
+      result.setContent(JSON.stringify({ ok: true }));
+      return result;
+    }
+
+    // All other actions require an arxivId
+    var arxivId = (data.arxivId || '').toString().trim();
     if (!arxivId) throw new Error('Missing arxivId');
 
     var sheet = SpreadsheetApp
@@ -127,7 +188,7 @@ function _findRow(sheet, cleanId) {
   var now       = new Date();
   var weekStart = _thisWeekMonday(now);
   var weekEnd   = new Date(weekStart);
-  weekEnd.setDate(weekEnd.getDate() + 7); // exclusive upper bound (Monday 00:00 next week)
+  weekEnd.setDate(weekEnd.getDate() + 7);
 
   var lastRow = sheet.getLastRow();
   for (var i = 2; i <= lastRow; i++) {
@@ -138,7 +199,6 @@ function _findRow(sheet, cleanId) {
     if (approved !== 'TRUE' || removed === 'TRUE') continue;
     if (_normalizeId(rawId) !== cleanId) continue;
 
-    // Reject rows outside the current week
     var ts = new Date(sheet.getRange(i, 1).getValue()); // column A — Timestamp
     if (isNaN(ts) || ts < weekStart || ts >= weekEnd) continue;
 
@@ -152,8 +212,8 @@ function _findRow(sheet, cleanId) {
  * using the local timezone of the Apps Script environment (matches the sheet).
  */
 function _thisWeekMonday(date) {
-  var d   = new Date(date);
-  var day = d.getDay(); // 0=Sun … 6=Sat
+  var d    = new Date(date);
+  var day  = d.getDay(); // 0=Sun … 6=Sat
   var diff = (day === 0) ? -6 : 1 - day;
   d.setDate(d.getDate() + diff);
   d.setHours(0, 0, 0, 0);
@@ -171,113 +231,130 @@ function _normalizeId(raw) {
   return s;
 }
 
+
 // ============================================================
 // Weekly Slack Reminder — Thursday 1 PM
 // ============================================================
-// Posts a summary to your Slack channel via an Incoming Webhook.
-//
-// SETUP:
-//   1. Go to https://api.slack.com/apps → Create App → From scratch
-//   2. Enable "Incoming Webhooks" and add a webhook for your channel
-//   3. Paste the webhook URL into SLACK_WEBHOOK_URL below
-//   4. Set SLACK_CHANNEL to your channel name (for display only)
-//
 // TRIGGER:
 //   Apps Script → Triggers → Add trigger
 //     Function:   weeklySlackReminder
 //     Event:      Time-driven → Week timer → Thursday → 1pm–2pm
 // ============================================================
 
-var SLACK_WEBHOOK_URL = 'https://hooks.slack.com/services/YOUR/WEBHOOK/URL';
-
-// ── Column indices for the PUBLIC sheet (1-indexed) ───────────
-// Adjust COL_NAME if your submitter name column is not column B.
-var COL_TIMESTAMP  = 1; // A — submission timestamp
-var COL_NAME       = 2; // B — submitter's name ← adjust if needed
-// COL_ARXIV, COL_APPROVED, COL_REMOVED, COL_VOTES already defined above
-
-// ── Main function ─────────────────────────────────────────────
-
 function weeklySlackReminder() {
   var ss          = SpreadsheetApp.getActiveSpreadsheet();
-  var publicSheet = ss.getSheetByName(SHEET_NAME);   // 'Public', defined above
+  var publicSheet = ss.getSheetByName(SHEET_NAME);
   if (!publicSheet) {
     Logger.log('Sheet "' + SHEET_NAME + '" not found — aborting reminder.');
     return;
   }
 
   var now       = new Date();
-  var weekStart = _thisWeekMonday(now); // reuses existing helper
+  var weekStart = _thisWeekMonday(now);
   var weekEnd   = new Date(weekStart);
   weekEnd.setDate(weekEnd.getDate() + 7);
 
-  var lastRow = publicSheet.getLastRow();
-  if (lastRow < 2) {
-    _postToSlack(_buildMessage([], null));
-    return;
+  var lastRow    = publicSheet.getLastRow();
+  var submitters = [];
+  var topPaper   = null;
+
+  if (lastRow >= 2) {
+    var data = publicSheet.getRange(2, 1, lastRow - 1, COL_VOTES).getValues();
+
+    data.forEach(function (row) {
+      var tsVal    = row[COL_TIMESTAMP - 1];
+      var name     = (row[COL_NAME - 1] || '').toString().trim();
+      var arxivId  = _normalizeId((row[COL_ARXIV - 1] || '').toString());
+      var approved = (row[COL_APPROVED - 1] || '').toString().trim().toUpperCase();
+      var removed  = (row[COL_REMOVED - 1] || '').toString().trim().toUpperCase();
+      var votes    = Number(row[COL_VOTES - 1]) || 0;
+
+      if (approved !== 'TRUE' || removed === 'TRUE') return;
+
+      var ts = tsVal instanceof Date ? tsVal : new Date(tsVal);
+      if (isNaN(ts) || ts < weekStart || ts >= weekEnd) return;
+
+      if (name && !submitters.includes(name)) submitters.push(name);
+
+      if (!topPaper || votes > topPaper.votes) {
+        topPaper = { arxivId: arxivId, votes: votes, name: name };
+      }
+    });
   }
 
-  // Read all relevant columns in one batch (faster than per-cell reads)
-  var data = publicSheet.getRange(2, 1, lastRow - 1, COL_VOTES).getValues();
+  // Read trending papers from the cached Trending tab (no live API calls needed)
+  var trending = _readTrendingFromSheet();
 
-  var submitters  = []; // names of people who submitted this week
-  var topPaper    = null; // { arxivId, votes, name }
+  _postToSlack(_buildMessage(submitters, topPaper, trending));
+}
+
+// ── Read trending from sheet ──────────────────────────────────
+
+/**
+ * Reads the Trending tab and returns an array parallel to INSPIRE_CATEGORIES,
+ * each element being an array of up to INSPIRE_RESULTS_PER_CATEGORY objects:
+ *   { rank, arxivId, title, authors, affiliation, citations, citationsNoSelf }
+ * Returns an empty array per category if the tab is missing or empty.
+ */
+function _readTrendingFromSheet() {
+  var ss            = SpreadsheetApp.getActiveSpreadsheet();
+  var trendingSheet = ss.getSheetByName(TRENDING_SHEET_NAME);
+  var result        = INSPIRE_CATEGORIES.map(function () { return []; });
+
+  if (!trendingSheet || trendingSheet.getLastRow() < 2) return result;
+
+  var lastRow = trendingSheet.getLastRow();
+  var data    = trendingSheet.getRange(2, 1, lastRow - 1, TCOL_CITATIONS_NOSELF).getValues();
 
   data.forEach(function (row) {
-    var tsVal    = row[COL_TIMESTAMP - 1];
-    var name     = (row[COL_NAME - 1] || '').toString().trim();
-    var arxivId  = _normalizeId((row[COL_ARXIV - 1] || '').toString());
-    var approved = (row[COL_APPROVED - 1] || '').toString().trim().toUpperCase();
-    var removed  = (row[COL_REMOVED - 1] || '').toString().trim().toUpperCase();
-    var votes    = Number(row[COL_VOTES - 1]) || 0;
+    var categoryLabel = (row[TCOL_CATEGORY - 1] || '').toString().trim();
+    var idx = INSPIRE_CATEGORIES.findIndex(function (c) { return c.label === categoryLabel; });
+    if (idx === -1) return;
 
-    // Skip unapproved or removed rows
-    if (approved !== 'TRUE' || removed === 'TRUE') return;
-
-    // Check timestamp falls within this week
-    var ts = tsVal instanceof Date ? tsVal : new Date(tsVal);
-    if (isNaN(ts) || ts < weekStart || ts >= weekEnd) return;
-
-    // Collect submitter name (deduplicated)
-    if (name && !submitters.includes(name)) submitters.push(name);
-
-    // Track highest-voted paper
-    if (!topPaper || votes > topPaper.votes) {
-      topPaper = { arxivId: arxivId, votes: votes, name: name };
-    }
+    result[idx].push({
+      rank:            Number(row[TCOL_RANK - 1]) || 0,
+      arxivId:         (row[TCOL_ARXIV_ID - 1] || '').toString().trim(),
+      title:           (row[TCOL_TITLE - 1] || '').toString().trim(),
+      authors:         (row[TCOL_AUTHORS - 1] || '').toString().trim(),
+      affiliation:     (row[TCOL_AFFILIATION - 1] || '').toString().trim(),
+      citations:       Number(row[TCOL_CITATIONS - 1]) || 0,
+      citationsNoSelf: Number(row[TCOL_CITATIONS_NOSELF - 1]) || 0
+    });
   });
 
-  _postToSlack(_buildMessage(submitters, topPaper));
+  // Sort each category by rank ascending
+  result.forEach(function (papers) {
+    papers.sort(function (a, b) { return a.rank - b.rank; });
+  });
+
+  return result;
 }
 
 // ── Message builder ───────────────────────────────────────────
 
-function _buildMessage(submitters, topPaper) {
-  var siteUrl = 'https://meighenbergers.github.io/jc-ppi/';
-  var lines   = [];
+function _buildMessage(submitters, topPaper, trending) {
+  var lines = [];
 
-  lines.push('*📄 Journal Club — weekly paper reminder* (meeting tomorrow at 2:30pm!)');
+  lines.push('*📄 Journal Club — weekly paper reminder* (meeting ' + MEETING_DAY + ' at ' + MEETING_TIME + '!)');
   lines.push('');
 
-  // Thank submitters
   if (submitters.length === 0) {
     lines.push('No papers submitted yet this week — be the first! 🚀');
   } else if (submitters.length === 1) {
     lines.push('Thank you *' + submitters[0] + '* for submitting! 🎉');
   } else {
-    var last  = submitters[submitters.length - 1];
-    var rest  = submitters.slice(0, -1);
+    var last = submitters[submitters.length - 1];
+    var rest = submitters.slice(0, -1);
     lines.push('Thank you *' + rest.join(', ') + '*, and *' + last + '* for submitting! 🎉');
   }
 
   lines.push('');
 
-  // Top paper
   if (topPaper && topPaper.arxivId) {
     var arxivUrl = 'https://arxiv.org/abs/' + topPaper.arxivId;
     if (topPaper.votes > 0) {
       lines.push(
-        '🏆 *Top paper so far:* <' + arxivUrl + '|' + topPaper.arxivId + '>' +
+        '🏆 *Top paper this week:* <' + arxivUrl + '|' + topPaper.arxivId + '>' +
         ' — ' + topPaper.votes + (topPaper.votes === 1 ? ' vote' : ' votes')
       );
     } else {
@@ -290,15 +367,44 @@ function _buildMessage(submitters, topPaper) {
 
   lines.push('');
 
-  // Nudge to submit
   if (submitters.length < 3) {
-    // Encourage more submissions if the list is thin
     lines.push('👀 Haven\'t submitted yet? There\'s still time — browse arXiv and share something interesting!');
   } else {
     lines.push('💡 Haven\'t submitted yet? You can still add a paper before the meeting.');
   }
+  lines.push('➡️  Submit here: ' + SITE_URL);
 
-  lines.push('➡️  Submit here: ' + siteUrl);
+  // Trending section — show only the top paper (rank 1) per category in Slack;
+  // link to the site for the full list of 3 per category.
+  var hasTrending = trending && trending.some(function (papers) { return papers.length > 0; });
+  if (hasTrending) {
+    lines.push('');
+    lines.push('─────────────────────────────────');
+    lines.push('*📡 Trending in hep-ph — past ' + INSPIRE_LOOKBACK_WEEKS + ' weeks* (full list on the site ↗)');
+    lines.push('_Ranked by citation count, excl. self-citations (via INSPIRE-HEP)_');
+    lines.push('');
+
+    INSPIRE_CATEGORIES.forEach(function (cat, i) {
+      var papers = trending[i];
+      lines.push(cat.emoji + ' *' + cat.label + '*');
+
+      if (!papers || papers.length === 0) {
+        lines.push('  _No data available._');
+      } else {
+        var top = papers[0]; // rank 1 only in the Slack message
+        var link = top.arxivId
+          ? '<https://arxiv.org/abs/' + top.arxivId + '|' + top.arxivId + '>'
+          : '_(no arXiv ID)_';
+        lines.push(
+          '  ' + link +
+          ' — *' + top.citationsNoSelf + '* citations excl. self / ' + top.citations + ' total'
+        );
+        if (top.title)       lines.push('  _' + top.title + '_');
+        if (top.authors)     lines.push('  ' + top.authors + (top.affiliation ? ' · ' + top.affiliation : ''));
+      }
+      lines.push('');
+    });
+  }
 
   return lines.join('\n');
 }
@@ -315,4 +421,149 @@ function _postToSlack(text) {
   };
   var response = UrlFetchApp.fetch(SLACK_WEBHOOK_URL, options);
   Logger.log('Slack response: ' + response.getContentText());
+}
+
+
+// ============================================================
+// Trending Papers Refresh — Monday & Wednesday 7 AM
+// ============================================================
+// TRIGGER (set up two triggers, one for each day):
+//   Apps Script → Triggers → Add trigger
+//     Function:   refreshTrendingPapers
+//     Event:      Time-driven → Week timer → Monday    → 7am–8am
+//     ---
+//     Function:   refreshTrendingPapers
+//     Event:      Time-driven → Week timer → Wednesday → 7am–8am
+//
+// SHEET SETUP — add a tab named "Trending" with this header row:
+//   A          B     C        D      E         F        G            H         I
+//   Category   Rank  ArxivId  Title  Abstract  Authors  Affiliation  Citations CitationsNoSelf
+// ============================================================
+
+function refreshTrendingPapers() {
+  var ss            = SpreadsheetApp.getActiveSpreadsheet();
+  var trendingSheet = ss.getSheetByName(TRENDING_SHEET_NAME);
+
+  if (!trendingSheet) {
+    Logger.log('Trending sheet "' + TRENDING_SHEET_NAME + '" not found — skipping refresh.');
+    return;
+  }
+
+  // Clear all data rows, keeping the header
+  var lastRow = trendingSheet.getLastRow();
+  if (lastRow > 1) {
+    trendingSheet.getRange(2, 1, lastRow - 1, trendingSheet.getLastColumn()).clearContent();
+  }
+
+  var cutoff  = new Date();
+  cutoff.setDate(cutoff.getDate() - (INSPIRE_LOOKBACK_WEEKS * 7));
+  var dateStr = Utilities.formatDate(cutoff, Session.getScriptTimeZone(), 'yyyy-MM-dd');
+
+  var newRows = [];
+
+  INSPIRE_CATEGORIES.forEach(function (cat, catIndex) {
+    if (catIndex > 0) Utilities.sleep(1000); // stay within INSPIRE rate limits
+
+    try {
+      var query = 'arxiv_categories hep-ph and date > ' + dateStr;
+      if (cat.extra) query += ' ' + cat.extra;
+
+      var url = 'https://inspirehep.net/api/literature'
+        + '?sort=mostcited'
+        + '&size=' + INSPIRE_RESULTS_PER_CATEGORY
+        + '&fields=arxiv_eprints,titles,abstracts,authors,collaborations,citation_count,citation_count_without_self_citations'
+        + '&q=' + encodeURIComponent(query);
+
+      var response = UrlFetchApp.fetch(url, { muteHttpExceptions: true });
+      var code     = response.getResponseCode();
+
+      if (code === 429) {
+        Logger.log('INSPIRE rate limit hit for "' + cat.label + '" — waiting 6s and retrying.');
+        Utilities.sleep(6000);
+        response = UrlFetchApp.fetch(url, { muteHttpExceptions: true });
+        code     = response.getResponseCode();
+      }
+
+      if (code !== 200) {
+        Logger.log('INSPIRE returned HTTP ' + code + ' for "' + cat.label + '"');
+        return;
+      }
+
+      var json = JSON.parse(response.getContentText());
+      if (!json.hits || !json.hits.hits || json.hits.hits.length === 0) {
+        Logger.log('No INSPIRE results for "' + cat.label + '"');
+        return;
+      }
+
+      json.hits.hits.forEach(function (hit, rank) {
+        var meta = hit.metadata;
+
+        // ── arXiv ID ──────────────────────────────────────
+        var arxivId = '';
+        if (meta.arxiv_eprints && meta.arxiv_eprints.length > 0) {
+          arxivId = (meta.arxiv_eprints[0].value || '').toString().trim();
+        }
+
+        // ── Title ─────────────────────────────────────────
+        var title = '';
+        if (meta.titles && meta.titles.length > 0) {
+          title = (meta.titles[0].title || '').toString().trim();
+        }
+
+        // ── Abstract ──────────────────────────────────────
+        var abstract = '';
+        if (meta.abstracts && meta.abstracts.length > 0) {
+          abstract = (meta.abstracts[0].value || '').toString().trim();
+          if (abstract.length > ABSTRACT_MAX_CHARS) {
+            abstract = abstract.substring(0, ABSTRACT_MAX_CHARS - 1) + '\u2026';
+          }
+        }
+
+        // ── Authors & affiliation ──────────────────────────
+        var authors     = '';
+        var affiliation = '';
+
+        // Prefer collaboration name if present
+        if (meta.collaborations && meta.collaborations.length > 0) {
+          authors     = (meta.collaborations[0].value || '').toString().trim() + ' Collaboration';
+          affiliation = '';
+        } else if (meta.authors && meta.authors.length > 0) {
+          var authorList = meta.authors;
+          var names = authorList.map(function (a) {
+            return (a.full_name || '').toString().trim();
+          }).filter(Boolean);
+
+          authors = (names.length <= 10) ? names.join(', ') : names[0] + ' et al.';
+
+          // Affiliation from the first author
+          var firstAuthor = authorList[0];
+          if (firstAuthor.affiliations && firstAuthor.affiliations.length > 0) {
+            affiliation = (firstAuthor.affiliations[0].value || '').toString().trim();
+          }
+        }
+
+        newRows.push([
+          cat.label,                                               // A Category
+          rank + 1,                                                // B Rank
+          arxivId,                                                 // C ArxivId
+          title,                                                   // D Title
+          abstract,                                                // E Abstract
+          authors,                                                 // F Authors
+          affiliation,                                             // G Affiliation
+          Number(meta.citation_count) || 0,                       // H Citations
+          Number(meta.citation_count_without_self_citations) || 0 // I CitationsNoSelf
+        ]);
+      });
+
+    } catch (err) {
+      Logger.log('Error fetching INSPIRE for "' + cat.label + '": ' + err.message);
+    }
+  });
+
+  if (newRows.length > 0) {
+    trendingSheet.getRange(2, 1, newRows.length, newRows[0].length).setValues(newRows);
+    Logger.log('Trending tab updated: ' + newRows.length + ' rows written.');
+  } else {
+    Logger.log('No trending rows to write — INSPIRE may be unavailable.');
+  }
 }

--- a/site/assets/css/style.css
+++ b/site/assets/css/style.css
@@ -1039,6 +1039,131 @@ footer a:hover {
   text-decoration: underline;
 }
 
+/* ── Submit top button ───────────────────────────────────── */
+
+.submit-top {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 1.25rem;
+}
+
+/* ── Trending section ────────────────────────────────────── */
+
+.trending-section {
+  margin-top: 3rem;
+  padding-top: 2rem;
+  border-top: 2px solid var(--border);
+}
+
+.trending-heading {
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: var(--text);
+  margin-bottom: 0.3rem;
+}
+
+.trending-subheading {
+  font-size: 0.85rem;
+  color: var(--muted);
+  margin-bottom: 1.5rem;
+  line-height: 1.55;
+}
+
+.trending-message {
+  padding: 0.85rem 1.1rem;
+  border-radius: var(--radius);
+  font-size: 0.9rem;
+}
+
+.trending-message--empty {
+  background: var(--bg-alt);
+  border: 1px dashed var(--border);
+  color: var(--muted);
+}
+
+.trending-message--error {
+  background: #fef2f2;
+  border: 1px solid #fca5a5;
+  border-left: 3px solid #f87171;
+  color: #7f1d1d;
+}
+
+.trending-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+}
+
+.trending-category {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.trending-cat-heading {
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+  padding-bottom: 0.4rem;
+  border-bottom: 2px solid var(--border);
+  margin-bottom: 0.1rem;
+}
+
+.trending-card {
+  background: var(--bg-alt);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent-sec);
+  border-radius: var(--radius);
+  padding: 0.75rem 0.9rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.trending-rank {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--accent-sec);
+  background: #ede7f6;
+  border: 1px solid #d1c4e9;
+  padding: 0.1em 0.5em;
+  border-radius: 999px;
+  align-self: flex-start;
+  margin-bottom: 0.15rem;
+}
+
+.trending-card-title {
+  font-size: 0.9rem;
+}
+
+.trending-badge-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+  margin-top: 0.35rem;
+}
+
+@media (max-width: 600px) {
+  .trending-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .submit-top {
+    justify-content: stretch;
+  }
+
+  .submit-top .btn {
+    display: block;
+    text-align: center;
+  }
+}
+
 /* ── Responsive ──────────────────────────────────────────── */
 
 @media (max-width: 600px) {

--- a/site/assets/js/app.js
+++ b/site/assets/js/app.js
@@ -20,6 +20,7 @@ import {
 } from './utils.js';
 import { fetchPaperMetadata } from './inspire.js';
 import { buildTable } from './table.js';
+import { renderTrending } from './trending.js';
 
 /** Re-fetch interval for the This Week page (ms). */
 const POLL_INTERVAL = 2 * 60 * 1000; // 2 minutes
@@ -60,6 +61,26 @@ async function fetchPapers() {
     .filter((r) => r.length > COL.timestamp && r[COL.timestamp])
     .filter((r) => (r[COL.approved] ?? '').trim().toUpperCase() === 'TRUE')
     .filter((r) => (r[COL.removed] ?? '').trim().toUpperCase() !== 'TRUE');
+}
+
+/**
+ * Fetch and parse the Trending CSV.
+ * Returns { state: 'ok'|'empty'|'error', rows: string[][] }.
+ * 'empty' rows are an empty array; trigger is attempted by the caller.
+ */
+async function fetchTrendingPapers() {
+  if (!CONFIG.trendingCsvUrl) return { state: 'empty', rows: [] };
+  try {
+    const res = await fetch(CONFIG.trendingCsvUrl, { cache: 'no-cache' });
+    if (!res.ok) return { state: 'error', rows: [] };
+    const text = await res.text();
+    const rows = parseCsv(text)
+      .slice(1)
+      .filter((r) => r.length > 0 && r[0]);
+    return { state: rows.length > 0 ? 'ok' : 'empty', rows };
+  } catch {
+    return { state: 'error', rows: [] };
+  }
 }
 
 /**
@@ -441,7 +462,11 @@ async function init() {
   const page = window.location.pathname.includes('archive') ? 'archive' : 'index';
 
   try {
-    const papers = await fetchPapers();
+    // Fetch submissions and (on index page) trending papers in parallel
+    const [papers, trendingResult] = await Promise.all([
+      fetchPapers(),
+      page === 'index' ? fetchTrendingPapers() : Promise.resolve(null),
+    ]);
 
     if (page === 'index') {
       await renderThisWeek(papers, container, { force: true });
@@ -458,6 +483,24 @@ async function init() {
           console.warn('Poll failed:', e);
         }
       }, POLL_INTERVAL);
+
+      // Render trending section
+      const trendingContainer = document.getElementById('trending');
+      if (trendingContainer) {
+        if (trendingResult.state === 'empty' && CONFIG.mutateUrl) {
+          // Attempt to trigger a refresh server-side, then show static message
+          try {
+            await fetch(CONFIG.mutateUrl, {
+              method: 'POST',
+              headers: { 'Content-Type': 'text/plain' },
+              body: JSON.stringify({ action: 'triggerTrendingRefresh' }),
+            });
+          } catch {
+            // Ignore — the static message handles both trigger-succeeded and trigger-failed
+          }
+        }
+        renderTrending(trendingResult.state, trendingResult.rows, trendingContainer);
+      }
     }
 
     if (page === 'archive') {

--- a/site/assets/js/config.js
+++ b/site/assets/js/config.js
@@ -17,6 +17,12 @@ export const CONFIG = {
   // Publish → link icon → copy URL.
   formUrl: 'https://forms.gle/j88TQiKnpScU9xY28',
 
+  // Published CSV export URL for the *Trending* tab.
+  // File → Share → Publish to web → choose the "Trending" tab → CSV → copy URL.
+  // Leave blank until the Trending tab has been created and published.
+  trendingCsvUrl:
+    'https://docs.google.com/spreadsheets/d/e/2PACX-1vSV30CUvQZhLXFlvt0HqGmGsMZqaapy4S_xIQAxYiJp1IBkkW515MNIdBvSnEaYRu9NQ1rOvCANW2ua/pub?gid=1574674238&single=true&output=csv',
+
   // Apps Script web app URL for vote/edit/remove mutations.
   // Deploy docs/appscript.gs as a web app (Execute as: Me, Anyone can access)
   // and paste the /exec URL here.  Leave blank to disable interactive controls.
@@ -200,4 +206,20 @@ export const COL = {
   editedComment: 6, // overrides comment when non-empty
   votes: 7, // running upvote count
   discussed: 8, // "TRUE" when the paper was starred as discussed at the JC meeting
+};
+
+// ── TRENDING TAB COLUMN MAP ─────────────────────────────────
+// Columns in the Trending tab CSV (0-indexed):
+//   A (0) Category  B (1) Rank  C (2) ArxivId  D (3) Title  E (4) Abstract
+//   F (5) Authors   G (6) Affiliation  H (7) Citations  I (8) CitationsNoSelf
+export const COL_TREND = {
+  category: 0,
+  rank: 1,
+  arxivId: 2,
+  title: 3,
+  abstract: 4,
+  authors: 5,
+  affiliation: 6,
+  citations: 7,
+  citationsNoSelf: 8,
 };

--- a/site/assets/js/trending.js
+++ b/site/assets/js/trending.js
@@ -1,0 +1,179 @@
+/* ============================================================
+   trending.js — Trending papers section renderer
+   ============================================================
+   Renders the Trending section from rows fetched from the
+   Trending Google Sheet tab (published as CSV).
+
+   Called from app.js with one of three states:
+     'ok'    — rows present, render normally
+     'empty' — no rows yet (refresh scheduled; show static message)
+     'error' — fetch failed (show error message)
+   ============================================================ */
+
+import { CONFIG, COL_TREND } from './config.js';
+import { normalizeArxivId, stripVersion } from './utils.js';
+
+/**
+ * Renders the trending section into `container`.
+ *
+ * @param {'ok'|'empty'|'error'} state
+ * @param {string[][]}           rows   - Parsed CSV rows (no header).
+ * @param {HTMLElement}          container
+ */
+export function renderTrending(state, rows, container) {
+  container.innerHTML = '';
+
+  const section = document.createElement('section');
+  section.className = 'trending-section';
+
+  const heading = document.createElement('h2');
+  heading.className = 'trending-heading';
+  heading.textContent = '📡 Trending in hep-ph';
+  section.appendChild(heading);
+
+  const subheading = document.createElement('p');
+  subheading.className = 'trending-subheading';
+  subheading.textContent =
+    `Most-cited papers over the past ${CONFIG.inspireLookbackWeeks ?? 4} weeks, ` +
+    'ranked by citation count excluding self-citations (via INSPIRE-HEP). ' +
+    'Refreshed Monday & Wednesday mornings.';
+  section.appendChild(subheading);
+
+  if (state === 'error') {
+    const msg = document.createElement('div');
+    msg.className = 'trending-message trending-message--error';
+    msg.textContent =
+      'Could not load trending papers. If this persists, please let the organiser know.';
+    section.appendChild(msg);
+    container.appendChild(section);
+    return;
+  }
+
+  if (state === 'empty') {
+    const msg = document.createElement('div');
+    msg.className = 'trending-message trending-message--empty';
+    msg.textContent =
+      'Trending papers are refreshed Monday and Wednesday mornings — check back soon.';
+    section.appendChild(msg);
+    container.appendChild(section);
+    return;
+  }
+
+  // Group rows by category, preserving INSPIRE_CATEGORIES order via order of appearance
+  const categoryOrder = [];
+  const byCategory = new Map();
+  rows.forEach((row) => {
+    const cat = (row[COL_TREND.category] ?? '').trim();
+    if (!cat) return;
+    if (!byCategory.has(cat)) {
+      byCategory.set(cat, []);
+      categoryOrder.push(cat);
+    }
+    byCategory.get(cat).push(row);
+  });
+
+  // Sort each category's papers by rank ascending
+  byCategory.forEach((papers) => {
+    papers.sort((a, b) => Number(a[COL_TREND.rank] ?? 0) - Number(b[COL_TREND.rank] ?? 0));
+  });
+
+  if (categoryOrder.length === 0) {
+    const msg = document.createElement('div');
+    msg.className = 'trending-message trending-message--empty';
+    msg.textContent =
+      'Trending papers are refreshed Monday and Wednesday mornings — check back soon.';
+    section.appendChild(msg);
+    container.appendChild(section);
+    return;
+  }
+
+  const grid = document.createElement('div');
+  grid.className = 'trending-grid';
+
+  categoryOrder.forEach((cat) => {
+    const papers = byCategory.get(cat);
+
+    const catBlock = document.createElement('div');
+    catBlock.className = 'trending-category';
+
+    const catHeading = document.createElement('h3');
+    catHeading.className = 'trending-cat-heading';
+    catHeading.textContent = cat;
+    catBlock.appendChild(catHeading);
+
+    papers.forEach((row) => {
+      const rank = Number(row[COL_TREND.rank] ?? 0);
+      const rawArxivId = (row[COL_TREND.arxivId] ?? '').trim();
+      const title = (row[COL_TREND.title] ?? '').trim();
+      const abstract = (row[COL_TREND.abstract] ?? '').trim();
+      const authors = (row[COL_TREND.authors] ?? '').trim();
+      const affiliation = (row[COL_TREND.affiliation] ?? '').trim();
+      const citations = Number(row[COL_TREND.citations] ?? 0);
+      const citationsNoSelf = Number(row[COL_TREND.citationsNoSelf] ?? 0);
+
+      const cleanId = rawArxivId ? stripVersion(normalizeArxivId(rawArxivId)) : '';
+
+      const card = document.createElement('div');
+      card.className = 'trending-card';
+
+      // ── Rank badge ────────────────────────────────────────
+      const rankBadge = document.createElement('span');
+      rankBadge.className = 'trending-rank';
+      rankBadge.textContent = `#${rank}`;
+      card.appendChild(rankBadge);
+
+      // ── Title ─────────────────────────────────────────────
+      if (title) {
+        const titleEl = document.createElement('div');
+        titleEl.className = 'paper-title trending-card-title';
+        titleEl.textContent = title;
+        card.appendChild(titleEl);
+      }
+
+      // ── Authors + affiliation ──────────────────────────────
+      if (authors) {
+        const authEl = document.createElement('div');
+        authEl.className = 'paper-comment';
+        authEl.textContent = affiliation ? `${authors} · ${affiliation}` : authors;
+        card.appendChild(authEl);
+      }
+
+      // ── Abstract ──────────────────────────────────────────
+      if (abstract) {
+        const absEl = document.createElement('div');
+        absEl.className = 'paper-abstract';
+        absEl.textContent = abstract;
+        card.appendChild(absEl);
+      }
+
+      // ── Badge row: arXiv link + citation count ─────────────
+      const badgeRow = document.createElement('div');
+      badgeRow.className = 'trending-badge-row';
+
+      if (cleanId) {
+        const arxivLink = document.createElement('a');
+        arxivLink.className = 'arxiv-link';
+        arxivLink.href = `https://arxiv.org/abs/${cleanId}`;
+        arxivLink.target = '_blank';
+        arxivLink.rel = 'noopener';
+        arxivLink.textContent = cleanId;
+        badgeRow.appendChild(arxivLink);
+      }
+
+      if (citations > 0 || citationsNoSelf > 0) {
+        const citeEl = document.createElement('span');
+        citeEl.className = 'cite-count';
+        citeEl.textContent = `${citationsNoSelf} citations (excl. self) / ${citations} total`;
+        badgeRow.appendChild(citeEl);
+      }
+
+      card.appendChild(badgeRow);
+      catBlock.appendChild(card);
+    });
+
+    grid.appendChild(catBlock);
+  });
+
+  section.appendChild(grid);
+  container.appendChild(section);
+}

--- a/site/index.html
+++ b/site/index.html
@@ -31,11 +31,14 @@
         <a href="./archive.html">Archive</a>
         <a href="./stats.html">Stats</a>
         <a href="./resources.html">Resources</a>
-        <a href="#" id="submit-link" target="_blank" rel="noopener">Submit a Paper ↗</a>
       </nav>
     </header>
 
     <main>
+      <div class="submit-top">
+        <a href="#" id="submit-link" target="_blank" rel="noopener" class="btn">Submit a Paper ↗</a>
+      </div>
+
       <section class="week-header">
         <h2>Papers for Discussion</h2>
         <p class="week-label" id="week-label">Loading…</p>
@@ -92,6 +95,7 @@
           </ul>
         </div>
       </div>
+      <div id="trending"></div>
     </main>
 
     <footer>


### PR DESCRIPTION
## Summary

Adds a **Trending Papers** section to the home page that surfaces the top-cited recent hep-ph papers from INSPIRE-HEP, grouped by category. Papers are fetched and cached in a new Google Sheet tab by an Apps Script function that fires on Monday and Wednesday mornings. The weekly Slack reminder is updated to include the top paper per category without making any live API calls at send time.

## Type of change

- [ ] Bug fix
- [x] New feature / enhancement
- [x] Content update (docs, README, etc.)
- [ ] CI / tooling change

## Checklist

- [x] Tested locally with `python -m http.server 8000 --directory site`
- [x] No broken links introduced
- [x] Formatting is consistent (run `prettier --check` or let CI verify)
- [x] README / docs updated if relevant

## What changed

### Site (`site/`)
- **`index.html`** — moved "Submit a Paper" button from the nav into the top of the page content; added `<div id="trending">` anchor for the new section
- **`assets/js/trending.js`** *(new)* — display-only renderer for the Trending section; groups rows by category, shows rank badges, title, authors/affiliation, and a clamped abstract; handles `ok` / `empty` / `error` states
- **`assets/js/app.js`** — fetches the Trending CSV in parallel with the submissions CSV on the index page; fires a silent background `triggerTrendingRefresh` POST when the CSV is empty (first deploy); calls `renderTrending`
- **`assets/js/config.js`** — adds `trendingCsvUrl` (blank until Trending tab is published) and the `COL_TREND` column map
- **`assets/css/style.css`** — styles for `.submit-top`, `.trending-section`, `.trending-grid`, `.trending-card`, `.trending-rank`, empty/error message states, and mobile responsive overrides

### Apps Script (`docs/appscript.gs`)
- Consolidated all user-editable variables into a clearly marked **CONFIGURATION block** at the top of the file
- Added `refreshTrendingPapers()` — queries INSPIRE-HEP top N papers per category, extracts arXiv ID / title / abstract / authors (≤10 names, otherwise "First et al.") / affiliation / citation counts, and writes to the Trending sheet tab; includes polite rate-limit handling (1 s sleep between categories, 6 s retry on HTTP 429)
- Added `_readTrendingFromSheet()` — reads the Trending tab and returns data structured by category; used by `weeklySlackReminder` so no live API call is made at send time
- Updated `weeklySlackReminder` / `_buildMessage` — appends top paper per category (rank 1) to the Slack message with a link to the site for the full list
- Updated `doPost` — added `triggerTrendingRefresh` action (no `arxivId` required)
- Removed duplicate function definitions that were present in the old file

### Docs
- **`README.md`** — added trending pipeline diagram to "How it works"; new "Trending papers" feature row; `trending.js` in file structure
- **`docs/SETUP.md`** — updated Step 5 function list; added **Step 6b** (create Trending tab, configure categories, add triggers, publish CSV); added `trendingCsvUrl` to the Step 7 config snippet
- **`docs/INTERACTIVITY.md`** — added "Trending refresh (automatic)" subsection explaining the empty-state background POST
- **`docs/CONTRIBUTING.md`** — added `trending.js` to the file map

## Related issues

<!-- Closes #… -->